### PR TITLE
Add remote API option and update docs

### DIFF
--- a/product-base/api/README.md
+++ b/product-base/api/README.md
@@ -4,15 +4,10 @@ Simple Node.js and SQLite API providing signup, login, random number generation 
 
 ## Local Setup
 
-1. Install dependencies
+Install dependencies and start the server:
 
 ```bash
 npm install
-```
-
-2. Start the server
-
-```bash
 npm start
 ```
 
@@ -20,39 +15,97 @@ The API listens on `http://localhost:4000` and stores its data in `database.sqli
 
 ## Endpoints
 
-### POST /signup
-Create a new user.
+### `POST /signup`
+Request:
+```json
+{
+  "full_name": "Jane Doe",
+  "email": "jane@example.com",
+  "password": "secret",
+  "address": "1 Main St",
+  "city": "Townsville",
+  "state": "CA",
+  "zip_code": "12345",
+  "birthday": "01/01/2000"
+}
+```
+Response:
+```json
+{ "id": 1 }
+```
 
-Body fields: `full_name`, `email`, `password`, `address`, `city`, `state`, `zip_code`, `birthday` (mm/dd/yyyy)
+### `POST /login`
+Request:
+```json
+{ "email": "jane@example.com", "password": "secret" }
+```
+Response:
+```json
+{
+  "id": 1,
+  "full_name": "Jane Doe",
+  "email": "jane@example.com",
+  "address": "1 Main St",
+  "city": "Townsville",
+  "state": "CA",
+  "zip_code": "12345",
+  "birthday": "01/01/2000"
+}
+```
 
-Response: `{ id }` or error if the email already exists.
+### `GET /rng`
+Headers:
+```
+rng-user-id: <user id>
+```
+Response:
+```json
+{ "number": 1234, "created_at": "2024-01-01T00:00:00.000Z" }
+```
 
-### POST /login
-Authenticate a user.
+### `GET /stats`
+Headers:
+```
+rng-user-id: <user id>
+```
+Response:
+```json
+{ "totalNumbersGenerated": 42, "bestNumber": 9999 }
+```
 
-Body fields: `email`, `password`
+### `GET /numbers`
+Headers:
+```
+rng-user-id: <user id>
+```
+Query parameters: `page` (default `1`) and `limit` (default `25`, max `100`).
+Response:
+```json
+{
+  "numbers": [
+    { "id": 1, "value": 1234, "created_at": "2024-01-01T00:00:00.000Z" }
+  ],
+  "page": 1,
+  "totalPages": 1,
+  "next": null
+}
+```
 
-Response: user model without password.
-
-### GET /rng
-Generate a random number between 1 and 10,000.
-
-Header: `rng-user-id` containing the caller's user id.
-
-Response: `{ number }`. The generated number is stored for the user.
-
-### GET /stats
-Return statistics for the authenticated user.
-
-Header: `rng-user-id`
-
-Response: `{ totalNumbersGenerated, bestNumber }`
-
-### POST /update-profile
-Update profile information for the authenticated user.
-
-Header: `rng-user-id`
-
-Body fields: `full_name`, `email`, `address`, `city`, `state`, `zip_code`, `birthday`
-
-Response: updated user model.
+### `POST /update-profile`
+Headers:
+```
+rng-user-id: <user id>
+```
+Request:
+```json
+{
+  "full_name": "Jane Doe",
+  "email": "jane@example.com",
+  "address": "1 Main St",
+  "city": "Townsville",
+  "state": "CA",
+  "zip_code": "12345",
+  "birthday": "01/01/2000"
+}
+```
+Response: same as request body with the user `id`.

--- a/product-base/web-app/README.md
+++ b/product-base/web-app/README.md
@@ -1,32 +1,29 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Web App
+
+This is the Next.js front-end for the demo product.
 
 ## Getting Started
 
-`npm install` to install `package.json` defined dependencies
-
-First, run the development server:
+Install dependencies:
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+npm install
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+### Available Commands
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+#### `npm run dev`
+Starts the Next.js dev server on [http://localhost:3000](http://localhost:3000) and points API requests to the local server at `http://localhost:4000`.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+#### `npm run remote`
+Runs the dev server but targets the deployed API at `http://playrng.us-east-1.elasticbeanstalk.com`.
 
-## Learn More
+#### `npm run build`
+Builds the app for production.
 
-To learn more about Next.js, take a look at the following resources:
+#### `npm run lint`
+Runs lint checks.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Editing
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+Pages live under `app/`. The server auto‑reloads when files change.

--- a/product-base/web-app/lib/api.ts
+++ b/product-base/web-app/lib/api.ts
@@ -1,4 +1,8 @@
-const baseUrl = process.env.NODE_ENV === 'development' ? 'http://localhost:4000' : '';
+// Base URL for API requests. Defaults to the local API when running
+// `npm run dev`. The `npm run remote` script sets `NEXT_PUBLIC_API_URL`
+// so the web app can talk to the deployed API instead.
+const baseUrl =
+  process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
 
 interface User {
   id: number;

--- a/product-base/web-app/package.json
+++ b/product-base/web-app/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "cross-env NODE_ENV=development next dev -H 0.0.0.0 -p 3000",
+    "remote": "cross-env NODE_ENV=development NEXT_PUBLIC_API_URL=http://playrng.us-east-1.elasticbeanstalk.com next dev -H 0.0.0.0 -p 3000",
     "build": "next build",
     "lint": "next lint"
   },


### PR DESCRIPTION
## Summary
- allow web app to target remote API via `npm run remote`
- document web app commands
- document API endpoints including `/numbers`

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689155edc9b8832e95fd783bdfbfc344