### PR TITLE
feat: add ios app skeleton

### DIFF
--- a/product-base/ios-app/.gitignore
+++ b/product-base/ios-app/.gitignore
@@ -1,0 +1,44 @@
+## Build artifacts
+build/
+DerivedData/
+
+## Xcode user settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## SwiftPM
+.swiftpm/
+.build/
+
+## CocoaPods
+Pods/
+Podfile.lock
+# If you want to commit Podfile.lock for reproducible builds, remove above line
+
+## Carthage
+Carthage/Build/
+
+## Fastlane
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots
+fastlane/test_output
+
+## Archives
+*.xcarchive
+
+## Playground stuff
+timeline.xctimeline
+playground.xcworkspace
+
+## Misc
+.DS_Store
+*.moved-aside
+*.xcuserstate

--- a/product-base/ios-app/RNGApp.xcodeproj/project.pbxproj
+++ b/product-base/ios-app/RNGApp.xcodeproj/project.pbxproj
@@ -1,0 +1,211 @@
+// !$*UTF8*$!
+{
+archiveVersion = 1;
+classes = {};
+objectVersion = 60;
+objects = {
+
+/* Begin PBXBuildFile section */
+62E4E46D08DE8749D10CD45B /* RNGAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1727A4718B7F994AFC988AD /* RNGAppApp.swift */; };
+7242BB97A66C23BC804AECFC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE80CEF3EEEAD5DCBAC0098C /* ContentView.swift */; };
+BBF43E2454DA7B59F56A135E /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78FEC8AE76BA99DD9C0D319 /* LoginView.swift */; };
+F40E2522C752923FC8EB4420 /* SignupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB61A8452B71F01117DBD6B9 /* SignupView.swift */; };
+BA98272A02055990E212CD18 /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A61F845CE7A349559C7090 /* DashboardView.swift */; };
+A3BE4C84DD474B391A54F9B8 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3DE6CF77EFB458215882E5E /* ProfileView.swift */; };
+5FA2321949039A474A3A9585 /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF86C7678F94B5CA6076694D /* HistoryView.swift */; };
+BE005D1BE09E2C75CD6DF52A /* NumberDisplayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58BD92F660AAFA9DC57F77A /* NumberDisplayView.swift */; };
+52A748F95ABEA0A7EA6356F9 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38BFC837175CD511C1D03180 /* API.swift */; };
+EDFBA29E514368E49456E0D5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 88EC2AFAA9A451886375690E /* Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+F1727A4718B7F994AFC988AD /* RNGAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RNGAppApp.swift; sourceTree = "<group>"; };
+CE80CEF3EEEAD5DCBAC0098C /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+E78FEC8AE76BA99DD9C0D319 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/LoginView.swift; sourceTree = "<group>"; };
+CB61A8452B71F01117DBD6B9 /* SignupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/SignupView.swift; sourceTree = "<group>"; };
+16A61F845CE7A349559C7090 /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/DashboardView.swift; sourceTree = "<group>"; };
+E3DE6CF77EFB458215882E5E /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/ProfileView.swift; sourceTree = "<group>"; };
+FF86C7678F94B5CA6076694D /* HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/HistoryView.swift; sourceTree = "<group>"; };
+D58BD92F660AAFA9DC57F77A /* NumberDisplayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/NumberDisplayView.swift; sourceTree = "<group>"; };
+38BFC837175CD511C1D03180 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
+88EC2AFAA9A451886375690E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+409876DD02946C85A45F6979 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+3F28ED26404B9B9B517C906A /* RNGApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; path = RNGApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+E3327DC542B334A19959A019 /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = (
+);
+runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+451406C8D1220967964C23C1 = {
+isa = PBXGroup;
+children = (
+09BD56AE699F287BB75F5ACA /* RNGApp */,
+1ADC17B757CBFBEF76F74DDF /* Products */,
+);
+sourceTree = "<group>";
+};
+09BD56AE699F287BB75F5ACA /* RNGApp */ = {
+isa = PBXGroup;
+children = (
+F1727A4718B7F994AFC988AD /* RNGAppApp.swift */,
+CE80CEF3EEEAD5DCBAC0098C /* ContentView.swift */,
+E78FEC8AE76BA99DD9C0D319 /* LoginView.swift */,
+CB61A8452B71F01117DBD6B9 /* SignupView.swift */,
+16A61F845CE7A349559C7090 /* DashboardView.swift */,
+E3DE6CF77EFB458215882E5E /* ProfileView.swift */,
+FF86C7678F94B5CA6076694D /* HistoryView.swift */,
+D58BD92F660AAFA9DC57F77A /* NumberDisplayView.swift */,
+38BFC837175CD511C1D03180 /* API.swift */,
+88EC2AFAA9A451886375690E /* Assets.xcassets */,
+409876DD02946C85A45F6979 /* Info.plist */,
+);
+path = RNGApp;
+sourceTree = "<group>";
+};
+1ADC17B757CBFBEF76F74DDF /* Products */ = {
+isa = PBXGroup;
+children = (
+3F28ED26404B9B9B517C906A /* RNGApp.app */,
+);
+name = Products;
+sourceTree = "<group>";
+};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+6E9597D9745FED0D2CE46EAF /* RNGApp */ = {
+isa = PBXNativeTarget;
+buildConfigurationList = 95E8F3D95DEB9CDA6112B66C /* Build configuration list for PBXNativeTarget "RNGApp" */;
+buildPhases = (
+3681BE572ECECCE886CAABB3 /* Sources */,
+E3327DC542B334A19959A019 /* Frameworks */,
+E205F925DE189AD9207661E4 /* Resources */,
+);
+buildRules = (
+);
+dependencies = (
+);
+name = RNGApp;
+productName = RNGApp;
+productReference = 3F28ED26404B9B9B517C906A /* RNGApp.app */;
+productType = "com.apple.product-type.application";
+};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+72FB0FB68C601759D7C57882 /* Project object */ = {
+isa = PBXProject;
+buildConfigurationList = 75500E5B9A4FF21A141D0292 /* Build configuration list for PBXProject "RNGApp" */;
+compatibilityVersion = "Xcode 14.0";
+developmentRegion = en;
+hasScannedForEncodings = 0;
+knownRegions = (
+en,
+);
+mainGroup = 451406C8D1220967964C23C1;
+productRefGroup = 1ADC17B757CBFBEF76F74DDF /* Products */;
+projectDirPath = "";
+projectRoot = "";
+targets = (
+6E9597D9745FED0D2CE46EAF /* RNGApp */,
+);
+};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+E205F925DE189AD9207661E4 /* Resources */ = {
+isa = PBXResourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+EDFBA29E514368E49456E0D5 /* Assets.xcassets in Resources */,
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+3681BE572ECECCE886CAABB3 /* Sources */ = {
+isa = PBXSourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+62E4E46D08DE8749D10CD45B /* RNGAppApp.swift in Sources */,
+7242BB97A66C23BC804AECFC /* ContentView.swift in Sources */,
+BBF43E2454DA7B59F56A135E /* LoginView.swift in Sources */,
+F40E2522C752923FC8EB4420 /* SignupView.swift in Sources */,
+BA98272A02055990E212CD18 /* DashboardView.swift in Sources */,
+A3BE4C84DD474B391A54F9B8 /* ProfileView.swift in Sources */,
+5FA2321949039A474A3A9585 /* HistoryView.swift in Sources */,
+BE005D1BE09E2C75CD6DF52A /* NumberDisplayView.swift in Sources */,
+52A748F95ABEA0A7EA6356F9 /* API.swift in Sources */,
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+4C6B8C773608B5B4AB30BFB3 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+INFOPLIST_FILE = RNGApp/Info.plist;
+LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+PRODUCT_BUNDLE_IDENTIFIER = com.example.RNGApp;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1,2";
+};
+name = Debug;
+};
+F64ACEA2339604666BC673BA /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+INFOPLIST_FILE = RNGApp/Info.plist;
+LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+PRODUCT_BUNDLE_IDENTIFIER = com.example.RNGApp;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1,2";
+};
+name = Release;
+};
+CE27467405DEB4B216F7852E /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+};
+name = Debug;
+};
+CB8F652FDE4DD83D6CD06842 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+};
+name = Release;
+};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+95E8F3D95DEB9CDA6112B66C /* Build configuration list for PBXNativeTarget "RNGApp" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+4C6B8C773608B5B4AB30BFB3 /* Debug */,
+F64ACEA2339604666BC673BA /* Release */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Debug;
+};
+75500E5B9A4FF21A141D0292 /* Build configuration list for PBXProject "RNGApp" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+CE27467405DEB4B216F7852E /* Debug */,
+CB8F652FDE4DD83D6CD06842 /* Release */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Debug;
+};
+/* End XCConfigurationList section */
+
+};
+rootObject = 72FB0FB68C601759D7C57882 /* Project object */;
+}

--- a/product-base/ios-app/RNGApp.xcodeproj/project.pbxproj
+++ b/product-base/ios-app/RNGApp.xcodeproj/project.pbxproj
@@ -1,211 +1,221 @@
 // !$*UTF8*$!
 {
-archiveVersion = 1;
-classes = {};
-objectVersion = 60;
-objects = {
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
 
 /* Begin PBXBuildFile section */
-62E4E46D08DE8749D10CD45B /* RNGAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1727A4718B7F994AFC988AD /* RNGAppApp.swift */; };
-7242BB97A66C23BC804AECFC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE80CEF3EEEAD5DCBAC0098C /* ContentView.swift */; };
-BBF43E2454DA7B59F56A135E /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78FEC8AE76BA99DD9C0D319 /* LoginView.swift */; };
-F40E2522C752923FC8EB4420 /* SignupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB61A8452B71F01117DBD6B9 /* SignupView.swift */; };
-BA98272A02055990E212CD18 /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A61F845CE7A349559C7090 /* DashboardView.swift */; };
-A3BE4C84DD474B391A54F9B8 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3DE6CF77EFB458215882E5E /* ProfileView.swift */; };
-5FA2321949039A474A3A9585 /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF86C7678F94B5CA6076694D /* HistoryView.swift */; };
-BE005D1BE09E2C75CD6DF52A /* NumberDisplayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58BD92F660AAFA9DC57F77A /* NumberDisplayView.swift */; };
-52A748F95ABEA0A7EA6356F9 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38BFC837175CD511C1D03180 /* API.swift */; };
-EDFBA29E514368E49456E0D5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 88EC2AFAA9A451886375690E /* Assets.xcassets */; };
+		52A748F95ABEA0A7EA6356F9 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38BFC837175CD511C1D03180 /* API.swift */; };
+		5FA2321949039A474A3A9585 /* Views/HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF86C7678F94B5CA6076694D /* Views/HistoryView.swift */; };
+		62E4E46D08DE8749D10CD45B /* RNGAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1727A4718B7F994AFC988AD /* RNGAppApp.swift */; };
+		7242BB97A66C23BC804AECFC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE80CEF3EEEAD5DCBAC0098C /* ContentView.swift */; };
+		A3BE4C84DD474B391A54F9B8 /* Views/ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3DE6CF77EFB458215882E5E /* Views/ProfileView.swift */; };
+		BA98272A02055990E212CD18 /* Views/DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A61F845CE7A349559C7090 /* Views/DashboardView.swift */; };
+		BBF43E2454DA7B59F56A135E /* Views/LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E78FEC8AE76BA99DD9C0D319 /* Views/LoginView.swift */; };
+		BE005D1BE09E2C75CD6DF52A /* Views/NumberDisplayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58BD92F660AAFA9DC57F77A /* Views/NumberDisplayView.swift */; };
+		EDFBA29E514368E49456E0D5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 88EC2AFAA9A451886375690E /* Assets.xcassets */; };
+		F40E2522C752923FC8EB4420 /* Views/SignupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB61A8452B71F01117DBD6B9 /* Views/SignupView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-F1727A4718B7F994AFC988AD /* RNGAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RNGAppApp.swift; sourceTree = "<group>"; };
-CE80CEF3EEEAD5DCBAC0098C /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
-E78FEC8AE76BA99DD9C0D319 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/LoginView.swift; sourceTree = "<group>"; };
-CB61A8452B71F01117DBD6B9 /* SignupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/SignupView.swift; sourceTree = "<group>"; };
-16A61F845CE7A349559C7090 /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/DashboardView.swift; sourceTree = "<group>"; };
-E3DE6CF77EFB458215882E5E /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/ProfileView.swift; sourceTree = "<group>"; };
-FF86C7678F94B5CA6076694D /* HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/HistoryView.swift; sourceTree = "<group>"; };
-D58BD92F660AAFA9DC57F77A /* NumberDisplayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/NumberDisplayView.swift; sourceTree = "<group>"; };
-38BFC837175CD511C1D03180 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
-88EC2AFAA9A451886375690E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-409876DD02946C85A45F6979 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-3F28ED26404B9B9B517C906A /* RNGApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; path = RNGApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		16A61F845CE7A349559C7090 /* Views/DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/DashboardView.swift; sourceTree = "<group>"; };
+		38BFC837175CD511C1D03180 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
+		3F28ED26404B9B9B517C906A /* RNGApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; path = RNGApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		409876DD02946C85A45F6979 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		88EC2AFAA9A451886375690E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		CB61A8452B71F01117DBD6B9 /* Views/SignupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/SignupView.swift; sourceTree = "<group>"; };
+		CE80CEF3EEEAD5DCBAC0098C /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		D58BD92F660AAFA9DC57F77A /* Views/NumberDisplayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/NumberDisplayView.swift; sourceTree = "<group>"; };
+		E3DE6CF77EFB458215882E5E /* Views/ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/ProfileView.swift; sourceTree = "<group>"; };
+		E78FEC8AE76BA99DD9C0D319 /* Views/LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/LoginView.swift; sourceTree = "<group>"; };
+		F1727A4718B7F994AFC988AD /* RNGAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RNGAppApp.swift; sourceTree = "<group>"; };
+		FF86C7678F94B5CA6076694D /* Views/HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/HistoryView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-E3327DC542B334A19959A019 /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = (
-);
-runOnlyForDeploymentPostprocessing = 0; };
+		E3327DC542B334A19959A019 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-451406C8D1220967964C23C1 = {
-isa = PBXGroup;
-children = (
-09BD56AE699F287BB75F5ACA /* RNGApp */,
-1ADC17B757CBFBEF76F74DDF /* Products */,
-);
-sourceTree = "<group>";
-};
-09BD56AE699F287BB75F5ACA /* RNGApp */ = {
-isa = PBXGroup;
-children = (
-F1727A4718B7F994AFC988AD /* RNGAppApp.swift */,
-CE80CEF3EEEAD5DCBAC0098C /* ContentView.swift */,
-E78FEC8AE76BA99DD9C0D319 /* LoginView.swift */,
-CB61A8452B71F01117DBD6B9 /* SignupView.swift */,
-16A61F845CE7A349559C7090 /* DashboardView.swift */,
-E3DE6CF77EFB458215882E5E /* ProfileView.swift */,
-FF86C7678F94B5CA6076694D /* HistoryView.swift */,
-D58BD92F660AAFA9DC57F77A /* NumberDisplayView.swift */,
-38BFC837175CD511C1D03180 /* API.swift */,
-88EC2AFAA9A451886375690E /* Assets.xcassets */,
-409876DD02946C85A45F6979 /* Info.plist */,
-);
-path = RNGApp;
-sourceTree = "<group>";
-};
-1ADC17B757CBFBEF76F74DDF /* Products */ = {
-isa = PBXGroup;
-children = (
-3F28ED26404B9B9B517C906A /* RNGApp.app */,
-);
-name = Products;
-sourceTree = "<group>";
-};
+		09BD56AE699F287BB75F5ACA /* RNGApp */ = {
+			isa = PBXGroup;
+			children = (
+				F1727A4718B7F994AFC988AD /* RNGAppApp.swift */,
+				CE80CEF3EEEAD5DCBAC0098C /* ContentView.swift */,
+				E78FEC8AE76BA99DD9C0D319 /* Views/LoginView.swift */,
+				CB61A8452B71F01117DBD6B9 /* Views/SignupView.swift */,
+				16A61F845CE7A349559C7090 /* Views/DashboardView.swift */,
+				E3DE6CF77EFB458215882E5E /* Views/ProfileView.swift */,
+				FF86C7678F94B5CA6076694D /* Views/HistoryView.swift */,
+				D58BD92F660AAFA9DC57F77A /* Views/NumberDisplayView.swift */,
+				38BFC837175CD511C1D03180 /* API.swift */,
+				88EC2AFAA9A451886375690E /* Assets.xcassets */,
+				409876DD02946C85A45F6979 /* Info.plist */,
+			);
+			path = RNGApp;
+			sourceTree = "<group>";
+		};
+		1ADC17B757CBFBEF76F74DDF /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3F28ED26404B9B9B517C906A /* RNGApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		451406C8D1220967964C23C1 = {
+			isa = PBXGroup;
+			children = (
+				09BD56AE699F287BB75F5ACA /* RNGApp */,
+				1ADC17B757CBFBEF76F74DDF /* Products */,
+			);
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-6E9597D9745FED0D2CE46EAF /* RNGApp */ = {
-isa = PBXNativeTarget;
-buildConfigurationList = 95E8F3D95DEB9CDA6112B66C /* Build configuration list for PBXNativeTarget "RNGApp" */;
-buildPhases = (
-3681BE572ECECCE886CAABB3 /* Sources */,
-E3327DC542B334A19959A019 /* Frameworks */,
-E205F925DE189AD9207661E4 /* Resources */,
-);
-buildRules = (
-);
-dependencies = (
-);
-name = RNGApp;
-productName = RNGApp;
-productReference = 3F28ED26404B9B9B517C906A /* RNGApp.app */;
-productType = "com.apple.product-type.application";
-};
+		6E9597D9745FED0D2CE46EAF /* RNGApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 95E8F3D95DEB9CDA6112B66C /* Build configuration list for PBXNativeTarget "RNGApp" */;
+			buildPhases = (
+				3681BE572ECECCE886CAABB3 /* Sources */,
+				E3327DC542B334A19959A019 /* Frameworks */,
+				E205F925DE189AD9207661E4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RNGApp;
+			productName = RNGApp;
+			productReference = 3F28ED26404B9B9B517C906A /* RNGApp.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-72FB0FB68C601759D7C57882 /* Project object */ = {
-isa = PBXProject;
-buildConfigurationList = 75500E5B9A4FF21A141D0292 /* Build configuration list for PBXProject "RNGApp" */;
-compatibilityVersion = "Xcode 14.0";
-developmentRegion = en;
-hasScannedForEncodings = 0;
-knownRegions = (
-en,
-);
-mainGroup = 451406C8D1220967964C23C1;
-productRefGroup = 1ADC17B757CBFBEF76F74DDF /* Products */;
-projectDirPath = "";
-projectRoot = "";
-targets = (
-6E9597D9745FED0D2CE46EAF /* RNGApp */,
-);
-};
+		72FB0FB68C601759D7C57882 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+			};
+			buildConfigurationList = 75500E5B9A4FF21A141D0292 /* Build configuration list for PBXProject "RNGApp" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 451406C8D1220967964C23C1;
+			productRefGroup = 1ADC17B757CBFBEF76F74DDF /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				6E9597D9745FED0D2CE46EAF /* RNGApp */,
+			);
+		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-E205F925DE189AD9207661E4 /* Resources */ = {
-isa = PBXResourcesBuildPhase;
-buildActionMask = 2147483647;
-files = (
-EDFBA29E514368E49456E0D5 /* Assets.xcassets in Resources */,
-);
-runOnlyForDeploymentPostprocessing = 0;
-};
+		E205F925DE189AD9207661E4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EDFBA29E514368E49456E0D5 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-3681BE572ECECCE886CAABB3 /* Sources */ = {
-isa = PBXSourcesBuildPhase;
-buildActionMask = 2147483647;
-files = (
-62E4E46D08DE8749D10CD45B /* RNGAppApp.swift in Sources */,
-7242BB97A66C23BC804AECFC /* ContentView.swift in Sources */,
-BBF43E2454DA7B59F56A135E /* LoginView.swift in Sources */,
-F40E2522C752923FC8EB4420 /* SignupView.swift in Sources */,
-BA98272A02055990E212CD18 /* DashboardView.swift in Sources */,
-A3BE4C84DD474B391A54F9B8 /* ProfileView.swift in Sources */,
-5FA2321949039A474A3A9585 /* HistoryView.swift in Sources */,
-BE005D1BE09E2C75CD6DF52A /* NumberDisplayView.swift in Sources */,
-52A748F95ABEA0A7EA6356F9 /* API.swift in Sources */,
-);
-runOnlyForDeploymentPostprocessing = 0;
-};
+		3681BE572ECECCE886CAABB3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				62E4E46D08DE8749D10CD45B /* RNGAppApp.swift in Sources */,
+				7242BB97A66C23BC804AECFC /* ContentView.swift in Sources */,
+				BBF43E2454DA7B59F56A135E /* Views/LoginView.swift in Sources */,
+				F40E2522C752923FC8EB4420 /* Views/SignupView.swift in Sources */,
+				BA98272A02055990E212CD18 /* Views/DashboardView.swift in Sources */,
+				A3BE4C84DD474B391A54F9B8 /* Views/ProfileView.swift in Sources */,
+				5FA2321949039A474A3A9585 /* Views/HistoryView.swift in Sources */,
+				BE005D1BE09E2C75CD6DF52A /* Views/NumberDisplayView.swift in Sources */,
+				52A748F95ABEA0A7EA6356F9 /* API.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-4C6B8C773608B5B4AB30BFB3 /* Debug */ = {
-isa = XCBuildConfiguration;
-buildSettings = {
-INFOPLIST_FILE = RNGApp/Info.plist;
-LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-PRODUCT_BUNDLE_IDENTIFIER = com.example.RNGApp;
-PRODUCT_NAME = "$(TARGET_NAME)";
-SWIFT_VERSION = 5.0;
-TARGETED_DEVICE_FAMILY = "1,2";
-};
-name = Debug;
-};
-F64ACEA2339604666BC673BA /* Release */ = {
-isa = XCBuildConfiguration;
-buildSettings = {
-INFOPLIST_FILE = RNGApp/Info.plist;
-LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
-PRODUCT_BUNDLE_IDENTIFIER = com.example.RNGApp;
-PRODUCT_NAME = "$(TARGET_NAME)";
-SWIFT_VERSION = 5.0;
-TARGETED_DEVICE_FAMILY = "1,2";
-};
-name = Release;
-};
-CE27467405DEB4B216F7852E /* Debug */ = {
-isa = XCBuildConfiguration;
-buildSettings = {
-};
-name = Debug;
-};
-CB8F652FDE4DD83D6CD06842 /* Release */ = {
-isa = XCBuildConfiguration;
-buildSettings = {
-};
-name = Release;
-};
+		4C6B8C773608B5B4AB30BFB3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = RNGApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.RNGApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		CB8F652FDE4DD83D6CD06842 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		CE27467405DEB4B216F7852E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		F64ACEA2339604666BC673BA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = RNGApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.RNGApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-95E8F3D95DEB9CDA6112B66C /* Build configuration list for PBXNativeTarget "RNGApp" */ = {
-isa = XCConfigurationList;
-buildConfigurations = (
-4C6B8C773608B5B4AB30BFB3 /* Debug */,
-F64ACEA2339604666BC673BA /* Release */,
-);
-defaultConfigurationIsVisible = 0;
-defaultConfigurationName = Debug;
-};
-75500E5B9A4FF21A141D0292 /* Build configuration list for PBXProject "RNGApp" */ = {
-isa = XCConfigurationList;
-buildConfigurations = (
-CE27467405DEB4B216F7852E /* Debug */,
-CB8F652FDE4DD83D6CD06842 /* Release */,
-);
-defaultConfigurationIsVisible = 0;
-defaultConfigurationName = Debug;
-};
+		75500E5B9A4FF21A141D0292 /* Build configuration list for PBXProject "RNGApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CE27467405DEB4B216F7852E /* Debug */,
+				CB8F652FDE4DD83D6CD06842 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		95E8F3D95DEB9CDA6112B66C /* Build configuration list for PBXNativeTarget "RNGApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4C6B8C773608B5B4AB30BFB3 /* Debug */,
+				F64ACEA2339604666BC673BA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 /* End XCConfigurationList section */
-
-};
-rootObject = 72FB0FB68C601759D7C57882 /* Project object */;
+	};
+	rootObject = 72FB0FB68C601759D7C57882 /* Project object */;
 }

--- a/product-base/ios-app/RNGApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/product-base/ios-app/RNGApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/product-base/ios-app/RNGApp/API.swift
+++ b/product-base/ios-app/RNGApp/API.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+struct User: Codable {
+    var id: Int
+    var full_name: String
+    var email: String
+    var address: String?
+    var city: String?
+    var state: String?
+    var zip_code: String?
+    var birthday: String?
+}
+
+struct Stats: Codable {
+    var totalNumbersGenerated: Int
+    var bestNumber: Int
+}
+
+struct NumberRecord: Codable, Identifiable {
+    var id: Int
+    var value: Int
+    var created_at: String
+}
+
+class APIService {
+    static let shared = APIService()
+    private let baseURL = URL(string: "http://localhost:4000")!
+
+    private func request<T: Decodable>(_ path: String, method: String = "GET", body: Data? = nil, userId: Int? = nil) async throws -> T {
+        var req = URLRequest(url: baseURL.appendingPathComponent(path))
+        req.httpMethod = method
+        if let body = body {
+            req.httpBody = body
+            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        if let id = userId {
+            req.setValue(String(id), forHTTPHeaderField: "rng-user-id")
+        }
+        let (data, response) = try await URLSession.shared.data(for: req)
+        guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
+            throw URLError(.badServerResponse)
+        }
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    func login(email: String, password: String) async throws -> User {
+        let body = try JSONEncoder().encode(["email": email, "password": password])
+        return try await request("/login", method: "POST", body: body)
+    }
+
+    struct SignupData: Codable {
+        var name: String
+        var email: String
+        var password: String
+        var address: String
+        var city: String
+        var state: String
+        var zip: String
+        var birthday: String
+    }
+
+    struct IdResponse: Decodable { let id: Int }
+
+    func signup(data: SignupData) async throws -> User {
+        let body = try JSONEncoder().encode([
+            "full_name": data.name,
+            "email": data.email,
+            "password": data.password,
+            "address": data.address,
+            "city": data.city,
+            "state": data.state,
+            "zip_code": data.zip,
+            "birthday": data.birthday
+        ])
+        let res: IdResponse = try await request("/signup", method: "POST", body: body)
+        return User(id: res.id, full_name: data.name, email: data.email, address: data.address, city: data.city, state: data.state, zip_code: data.zip, birthday: data.birthday)
+    }
+
+    func generateNumber(userId: Int) async throws -> Int {
+        struct NumRes: Decodable { let number: Int }
+        let res: NumRes = try await request("/rng", userId: userId)
+        return res.number
+    }
+
+    func getStats(userId: Int) async throws -> Stats {
+        try await request("/stats", userId: userId)
+    }
+
+    struct UpdateProfileData: Codable {
+        var full_name: String
+        var email: String
+        var address: String
+        var city: String
+        var state: String
+        var zip_code: String
+        var birthday: String
+    }
+
+    func updateProfile(data: UpdateProfileData, userId: Int) async throws -> User {
+        let body = try JSONEncoder().encode(data)
+        return try await request("/update-profile", method: "POST", body: body, userId: userId)
+    }
+
+    struct NumbersResponse: Decodable {
+        var numbers: [NumberRecord]
+        var page: Int
+        var totalPages: Int
+        var next: String?
+    }
+
+    func getNumberHistory(page: Int, limit: Int, userId: Int) async throws -> NumbersResponse {
+        let query = "?page=\(page)&limit=\(limit)"
+        return try await request("/numbers" + query, userId: userId)
+    }
+}
+
+class SessionManager: ObservableObject {
+    @Published var user: User? {
+        didSet { saveUser() }
+    }
+
+    init() {
+        if let data = UserDefaults.standard.data(forKey: "rng_user"),
+           let u = try? JSONDecoder().decode(User.self, from: data) {
+            self.user = u
+        }
+    }
+
+    func login(email: String, password: String) async throws {
+        let u = try await APIService.shared.login(email: email, password: password)
+        await MainActor.run { self.user = u }
+    }
+
+    func signup(data: APIService.SignupData) async throws {
+        let u = try await APIService.shared.signup(data: data)
+        await MainActor.run { self.user = u }
+    }
+
+    func logout() {
+        user = nil
+    }
+
+    private func saveUser() {
+        if let u = user, let data = try? JSONEncoder().encode(u) {
+            UserDefaults.standard.set(data, forKey: "rng_user")
+        } else {
+            UserDefaults.standard.removeObject(forKey: "rng_user")
+        }
+    }
+}

--- a/product-base/ios-app/RNGApp/API.swift
+++ b/product-base/ios-app/RNGApp/API.swift
@@ -24,10 +24,24 @@ struct NumberRecord: Codable, Identifiable {
 
 class APIService {
     static let shared = APIService()
-    private let baseURL = URL(string: "http://localhost:4000")!
+    private let baseURL = URL(string: "http://playrng.us-east-1.elasticbeanstalk.com")!
 
-    private func request<T: Decodable>(_ path: String, method: String = "GET", body: Data? = nil, userId: Int? = nil) async throws -> T {
-        var req = URLRequest(url: baseURL.appendingPathComponent(path))
+    // Generic request method
+    private func request<T: Decodable>(
+        path: String,
+        method: String = "GET",
+        queryItems: [URLQueryItem]? = nil,
+        body: Data? = nil,
+        userId: Int? = nil
+    ) async throws -> T {
+        var components = URLComponents(url: baseURL.appendingPathComponent(path), resolvingAgainstBaseURL: false)!
+        components.queryItems = queryItems
+
+        guard let finalURL = components.url else {
+            throw URLError(.badURL)
+        }
+
+        var req = URLRequest(url: finalURL)
         req.httpMethod = method
         if let body = body {
             req.httpBody = body
@@ -36,16 +50,41 @@ class APIService {
         if let id = userId {
             req.setValue(String(id), forHTTPHeaderField: "rng-user-id")
         }
+
         let (data, response) = try await URLSession.shared.data(for: req)
-        guard let http = response as? HTTPURLResponse, 200..<300 ~= http.statusCode else {
+        guard let http = response as? HTTPURLResponse else {
             throw URLError(.badServerResponse)
         }
+
+        // Debug logging
+        print("➡️ Request: \(req.httpMethod ?? "") \(finalURL.absoluteString)")
+        if let body = body {
+            print("📦 Body:", String(data: body, encoding: .utf8) ?? "<binary>")
+        }
+        print("⬅️ Status: \(http.statusCode)")
+        print("⬅️ Raw Response:", String(data: data, encoding: .utf8) ?? "<non-UTF8>")
+
+        guard (200..<300).contains(http.statusCode) else {
+            throw NSError(
+                domain: "HTTPError",
+                code: http.statusCode,
+                userInfo: [
+                    NSLocalizedDescriptionKey: HTTPURLResponse.localizedString(forStatusCode: http.statusCode)
+                ]
+            )
+        }
+
         return try JSONDecoder().decode(T.self, from: data)
     }
 
+    // MARK: - Auth
+
     func login(email: String, password: String) async throws -> User {
-        let body = try JSONEncoder().encode(["email": email, "password": password])
-        return try await request("/login", method: "POST", body: body)
+        let body = try JSONEncoder().encode([
+            "email": email,
+            "password": password
+        ])
+        return try await request(path: "login", method: "POST", body: body)
     }
 
     struct SignupData: Codable {
@@ -72,19 +111,52 @@ class APIService {
             "zip_code": data.zip,
             "birthday": data.birthday
         ])
-        let res: IdResponse = try await request("/signup", method: "POST", body: body)
-        return User(id: res.id, full_name: data.name, email: data.email, address: data.address, city: data.city, state: data.state, zip_code: data.zip, birthday: data.birthday)
+        let res: IdResponse = try await request(path: "signup", method: "POST", body: body)
+        return User(
+            id: res.id,
+            full_name: data.name,
+            email: data.email,
+            address: data.address,
+            city: data.city,
+            state: data.state,
+            zip_code: data.zip,
+            birthday: data.birthday
+        )
     }
+
+    // MARK: - Numbers
 
     func generateNumber(userId: Int) async throws -> Int {
         struct NumRes: Decodable { let number: Int }
-        let res: NumRes = try await request("/rng", userId: userId)
+        let res: NumRes = try await request(path: "rng", userId: userId)
         return res.number
     }
 
-    func getStats(userId: Int) async throws -> Stats {
-        try await request("/stats", userId: userId)
+    func getNumberHistory(page: Int, limit: Int, userId: Int) async throws -> NumbersResponse {
+        return try await request(
+            path: "numbers",
+            queryItems: [
+                URLQueryItem(name: "page", value: "\(page)"),
+                URLQueryItem(name: "limit", value: "\(limit)")
+            ],
+            userId: userId
+        )
     }
+
+    struct NumbersResponse: Decodable {
+        var numbers: [NumberRecord]
+        var page: Int
+        var totalPages: Int
+        var next: String?
+    }
+
+    // MARK: - Stats
+
+    func getStats(userId: Int) async throws -> Stats {
+        try await request(path: "stats", userId: userId)
+    }
+
+    // MARK: - Profile
 
     struct UpdateProfileData: Codable {
         var full_name: String
@@ -98,21 +170,11 @@ class APIService {
 
     func updateProfile(data: UpdateProfileData, userId: Int) async throws -> User {
         let body = try JSONEncoder().encode(data)
-        return try await request("/update-profile", method: "POST", body: body, userId: userId)
-    }
-
-    struct NumbersResponse: Decodable {
-        var numbers: [NumberRecord]
-        var page: Int
-        var totalPages: Int
-        var next: String?
-    }
-
-    func getNumberHistory(page: Int, limit: Int, userId: Int) async throws -> NumbersResponse {
-        let query = "?page=\(page)&limit=\(limit)"
-        return try await request("/numbers" + query, userId: userId)
+        return try await request(path: "update-profile", method: "POST", body: body, userId: userId)
     }
 }
+
+// MARK: - Session Manager
 
 class SessionManager: ObservableObject {
     @Published var user: User? {

--- a/product-base/ios-app/RNGApp/Assets.xcassets/Contents.json
+++ b/product-base/ios-app/RNGApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/product-base/ios-app/RNGApp/ContentView.swift
+++ b/product-base/ios-app/RNGApp/ContentView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject var session: SessionManager
+
+    var body: some View {
+        NavigationStack {
+            if session.user != nil {
+                DashboardView()
+            } else {
+                LoginView()
+            }
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+        .environmentObject(SessionManager())
+}

--- a/product-base/ios-app/RNGApp/Info.plist
+++ b/product-base/ios-app/RNGApp/Info.plist
@@ -2,24 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>CFBundleDevelopmentRegion</key>
-  <string>en</string>
-  <key>CFBundleExecutable</key>
-  <string>$(EXECUTABLE_NAME)</string>
-  <key>CFBundleIdentifier</key>
-  <string>com.example.RNGApp</string>
-  <key>CFBundleName</key>
-  <string>RNGApp</string>
-  <key>CFBundlePackageType</key>
-  <string>APPL</string>
-  <key>CFBundleShortVersionString</key>
-  <string>1.0</string>
-  <key>CFBundleVersion</key>
-  <string>1</string>
-  <key>UIApplicationSceneManifest</key>
-  <dict>
-    <key>UIApplicationSupportsMultipleScenes</key>
-    <false/>
-  </dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.example.RNGApp</string>
+	<key>CFBundleName</key>
+	<string>RNGApp</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
 </dict>
 </plist>

--- a/product-base/ios-app/RNGApp/Info.plist
+++ b/product-base/ios-app/RNGApp/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.example.RNGApp</string>
+  <key>CFBundleName</key>
+  <string>RNGApp</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>UIApplicationSceneManifest</key>
+  <dict>
+    <key>UIApplicationSupportsMultipleScenes</key>
+    <false/>
+  </dict>
+</dict>
+</plist>

--- a/product-base/ios-app/RNGApp/RNGAppApp.swift
+++ b/product-base/ios-app/RNGApp/RNGAppApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct RNGAppApp: App {
+    @StateObject private var session = SessionManager()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(session)
+        }
+    }
+}

--- a/product-base/ios-app/RNGApp/Views/DashboardView.swift
+++ b/product-base/ios-app/RNGApp/Views/DashboardView.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+
+struct DashboardView: View {
+    @EnvironmentObject var session: SessionManager
+    @State private var isGenerating = false
+    @State private var targetNumber: Int?
+    @State private var history: [Int] = []
+
+    var body: some View {
+        ZStack {
+            LinearGradient(colors: [.indigo, .purple, .pink], startPoint: .topLeading, endPoint: .bottomTrailing)
+                .ignoresSafeArea()
+            VStack {
+                HStack {
+                    Spacer()
+                    NavigationLink(destination: ProfileView()) {
+                        Image(systemName: "person.circle")
+                            .font(.title)
+                            .foregroundColor(.white)
+                    }
+                }
+                .padding()
+                Text("RNG")
+                    .font(.system(size: 48, weight: .bold))
+                    .foregroundColor(.white)
+                Text("Your Random Number Generator")
+                    .foregroundColor(.white.opacity(0.8))
+                Spacer()
+                NumberDisplayView(isGenerating: isGenerating, targetNumber: targetNumber) { final in
+                    history.insert(final, at: 0)
+                    isGenerating = false
+                }
+                Spacer()
+                if !history.isEmpty && !isGenerating {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack {
+                            ForEach(history.prefix(5), id: \.self) { num in
+                                Text("\(num)")
+                                    .padding(8)
+                                    .background(Color.white.opacity(0.2))
+                                    .cornerRadius(12)
+                                    .foregroundColor(.white)
+                            }
+                        }
+                    }
+                }
+                Button(action: generate) {
+                    Text("Generate").bold()
+                }
+                .frame(width: 120, height: 120)
+                .background(LinearGradient(colors: [.yellow, .orange], startPoint: .topLeading, endPoint: .bottomTrailing))
+                .foregroundColor(.white)
+                .clipShape(Circle())
+                .padding(.bottom, 40)
+            }
+        }
+        .navigationBarBackButtonHidden(true)
+    }
+
+    func generate() {
+        guard let user = session.user, !isGenerating else { return }
+        isGenerating = true
+        Task {
+            do {
+                let num = try await APIService.shared.generateNumber(userId: user.id)
+                targetNumber = num
+            } catch {
+                isGenerating = false
+            }
+        }
+    }
+}

--- a/product-base/ios-app/RNGApp/Views/HistoryView.swift
+++ b/product-base/ios-app/RNGApp/Views/HistoryView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct HistoryView: View {
+    @EnvironmentObject var session: SessionManager
+    @State private var numbers: [NumberRecord] = []
+
+    var body: some View {
+        ZStack {
+            LinearGradient(colors: [.blue, .purple, .pink], startPoint: .topLeading, endPoint: .bottomTrailing)
+                .ignoresSafeArea()
+            List(numbers) { item in
+                HStack {
+                    Text("\(item.value)")
+                    Spacer()
+                    Text(item.created_at)
+                        .font(.caption)
+                }
+                .foregroundColor(.white)
+            }
+            .scrollContentBackground(.hidden)
+        }
+        .onAppear { load() }
+        .navigationTitle("History")
+    }
+
+    func load() {
+        guard let id = session.user?.id else { return }
+        Task {
+            if let res = try? await APIService.shared.getNumberHistory(page: 1, limit: 25, userId: id) {
+                await MainActor.run { numbers = res.numbers }
+            }
+        }
+    }
+}

--- a/product-base/ios-app/RNGApp/Views/LoginView.swift
+++ b/product-base/ios-app/RNGApp/Views/LoginView.swift
@@ -18,7 +18,7 @@ struct LoginView: View {
                     .foregroundColor(.white.opacity(0.8))
                 TextField("Email", text: $email)
                     .textContentType(.emailAddress)
-                    .keyboardType(.emailAddress)
+//                    .keyboardType(.emailAddress)
                     .padding()
                     .background(Color.white)
                     .cornerRadius(16)
@@ -51,7 +51,7 @@ struct LoginView: View {
             do {
                 try await session.login(email: email, password: password)
             } catch {
-                // handle error
+                print("Login failed:", error)
             }
             isLoading = false
         }

--- a/product-base/ios-app/RNGApp/Views/LoginView.swift
+++ b/product-base/ios-app/RNGApp/Views/LoginView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct LoginView: View {
+    @EnvironmentObject var session: SessionManager
+    @State private var email = ""
+    @State private var password = ""
+    @State private var isLoading = false
+
+    var body: some View {
+        ZStack {
+            LinearGradient(colors: [.purple, .pink, .red], startPoint: .topLeading, endPoint: .bottomTrailing)
+                .ignoresSafeArea()
+            VStack(spacing: 20) {
+                Text("RNG")
+                    .font(.system(size: 48, weight: .bold))
+                    .foregroundColor(.white)
+                Text("Welcome back!")
+                    .foregroundColor(.white.opacity(0.8))
+                TextField("Email", text: $email)
+                    .textContentType(.emailAddress)
+                    .keyboardType(.emailAddress)
+                    .padding()
+                    .background(Color.white)
+                    .cornerRadius(16)
+                SecureField("Password", text: $password)
+                    .padding()
+                    .background(Color.white)
+                    .cornerRadius(16)
+                Button(action: login) {
+                    if isLoading {
+                        ProgressView().tint(.white)
+                    } else {
+                        Text("Login").bold()
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(Color.purple)
+                .foregroundColor(.white)
+                .cornerRadius(16)
+                NavigationLink("Sign up", destination: SignupView())
+                    .foregroundColor(.white)
+            }
+            .padding()
+        }
+    }
+
+    func login() {
+        Task {
+            isLoading = true
+            do {
+                try await session.login(email: email, password: password)
+            } catch {
+                // handle error
+            }
+            isLoading = false
+        }
+    }
+}

--- a/product-base/ios-app/RNGApp/Views/NumberDisplayView.swift
+++ b/product-base/ios-app/RNGApp/Views/NumberDisplayView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct NumberDisplayView: View {
+    var isGenerating: Bool
+    var targetNumber: Int?
+    var onComplete: (Int) -> Void
+
+    @State private var current: Int = 0
+    @State private var timer: Timer?
+
+    var body: some View {
+        Text("\(current)")
+            .font(.system(size: 72, weight: .bold))
+            .foregroundColor(.white)
+            .onChange(of: targetNumber) { _ in start() }
+            .onDisappear { timer?.invalidate() }
+    }
+
+    func start() {
+        guard let target = targetNumber else { return }
+        current = 0
+        timer?.invalidate()
+        let startDate = Date()
+        let duration: TimeInterval = 5
+        timer = Timer.scheduledTimer(withTimeInterval: 0.02, repeats: true) { t in
+            let progress = min(Date().timeIntervalSince(startDate)/duration, 1)
+            let eased = progress * progress * (3 - 2 * progress)
+            current = Int(Double(target) * eased)
+            if progress >= 1 {
+                t.invalidate()
+                current = target
+                onComplete(target)
+            }
+        }
+    }
+}

--- a/product-base/ios-app/RNGApp/Views/ProfileView.swift
+++ b/product-base/ios-app/RNGApp/Views/ProfileView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+struct ProfileView: View {
+    @EnvironmentObject var session: SessionManager
+    @State private var stats = Stats(totalNumbersGenerated: 0, bestNumber: 0)
+
+    var body: some View {
+        ZStack {
+            LinearGradient(colors: [.blue, .purple, .pink], startPoint: .topLeading, endPoint: .bottomTrailing)
+                .ignoresSafeArea()
+            VStack(spacing: 20) {
+                HStack {
+                    NavigationLink(destination: DashboardView()) {
+                        Image(systemName: "arrow.left")
+                            .foregroundColor(.white)
+                    }
+                    Spacer()
+                }
+                .padding()
+                if let user = session.user {
+                    VStack(spacing: 8) {
+                        Text(user.full_name)
+                            .font(.title)
+                            .foregroundColor(.white)
+                        Text(user.email)
+                            .foregroundColor(.white.opacity(0.8))
+                    }
+                    HStack {
+                        VStack {
+                            Text("\(stats.totalNumbersGenerated)")
+                            Text("Generated")
+                        }
+                        .padding()
+                        .background(Color.white.opacity(0.2))
+                        .cornerRadius(12)
+                        .foregroundColor(.white)
+                        VStack {
+                            Text("\(stats.bestNumber)")
+                            Text("Best")
+                        }
+                        .padding()
+                        .background(Color.white.opacity(0.2))
+                        .cornerRadius(12)
+                        .foregroundColor(.white)
+                    }
+                    NavigationLink("Number History", destination: HistoryView())
+                        .padding()
+                        .background(Color.blue.opacity(0.8))
+                        .cornerRadius(12)
+                        .foregroundColor(.white)
+                    Button("Logout") {
+                        session.logout()
+                    }
+                    .padding()
+                    .background(Color.red)
+                    .cornerRadius(12)
+                    .foregroundColor(.white)
+                }
+                Spacer()
+            }
+        }
+        .onAppear { load() }
+        .navigationBarBackButtonHidden(true)
+    }
+
+    func load() {
+        guard let id = session.user?.id else { return }
+        Task {
+            if let s = try? await APIService.shared.getStats(userId: id) {
+                await MainActor.run { stats = s }
+            }
+        }
+    }
+}

--- a/product-base/ios-app/RNGApp/Views/SignupView.swift
+++ b/product-base/ios-app/RNGApp/Views/SignupView.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+struct SignupView: View {
+    @Environment(\.dismiss) var dismiss
+    @EnvironmentObject var session: SessionManager
+    @State private var data = APIService.SignupData(name: "", email: "", password: "", address: "", city: "", state: "", zip: "", birthday: "")
+    @State private var isLoading = false
+
+    var body: some View {
+        ZStack {
+            LinearGradient(colors: [.purple, .pink, .red], startPoint: .topLeading, endPoint: .bottomTrailing)
+                .ignoresSafeArea()
+            ScrollView {
+                VStack(spacing: 12) {
+                    Text("Create Account")
+                        .font(.title)
+                        .foregroundColor(.white)
+                    Group {
+                        TextField("Full Name", text: $data.name)
+                        TextField("Email", text: $data.email).keyboardType(.emailAddress)
+                        SecureField("Password", text: $data.password)
+                        TextField("Address", text: $data.address)
+                        TextField("City", text: $data.city)
+                        TextField("State", text: $data.state)
+                        TextField("ZIP", text: $data.zip)
+                        TextField("Birthday (YYYY-MM-DD)", text: $data.birthday)
+                    }
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .autocapitalization(.none)
+                    .disableAutocorrection(true)
+                    Button(action: signup) {
+                        if isLoading { ProgressView().tint(.white) } else { Text("Sign Up").bold() }
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.purple)
+                    .foregroundColor(.white)
+                    .cornerRadius(16)
+                }
+                .padding()
+            }
+        }
+    }
+
+    func signup() {
+        Task {
+            isLoading = true
+            do {
+                try await session.signup(data: data)
+                dismiss()
+            } catch {
+                // handle error
+            }
+            isLoading = false
+        }
+    }
+}

--- a/product-base/ios-app/RNGApp/Views/SignupView.swift
+++ b/product-base/ios-app/RNGApp/Views/SignupView.swift
@@ -17,7 +17,7 @@ struct SignupView: View {
                         .foregroundColor(.white)
                     Group {
                         TextField("Full Name", text: $data.name)
-                        TextField("Email", text: $data.email).keyboardType(.emailAddress)
+                        TextField("Email", text: $data.email)
                         SecureField("Password", text: $data.password)
                         TextField("Address", text: $data.address)
                         TextField("City", text: $data.city)
@@ -26,7 +26,7 @@ struct SignupView: View {
                         TextField("Birthday (YYYY-MM-DD)", text: $data.birthday)
                     }
                     .textFieldStyle(RoundedBorderTextFieldStyle())
-                    .autocapitalization(.none)
+//                    .autocapitalization(.none)
                     .disableAutocorrection(true)
                     Button(action: signup) {
                         if isLoading { ProgressView().tint(.white) } else { Text("Sign Up").bold() }


### PR DESCRIPTION
## Summary
- add SwiftUI-based iOS app mirroring web app flows
- wire up API service for login, signup, stats and history

## Testing
- `swiftc product-base/ios-app/RNGApp/RNGAppApp.swift -o /tmp/app` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68924af06168832e9399503168304fcb