### PR TITLE
feat: persist android login and update theme

### DIFF
--- a/product-base/android-app/app/build.gradle.kts
+++ b/product-base/android-app/app/build.gradle.kts
@@ -7,12 +7,12 @@ plugins {
 
 android {
     namespace = "com.lucra.android"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
-        applicationId = "com.lucra.android"
+        applicationId = "com.rng.android"
         minSdk = 24
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
 
@@ -35,15 +35,15 @@ android {
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.12.0")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.4")
-    implementation("androidx.compose.ui:ui:1.5.3")
-    implementation("androidx.compose.material3:material3:1.1.2")
-    implementation("androidx.activity:activity-compose:1.7.2")
-    implementation("androidx.navigation:navigation-compose:2.7.4")
+    implementation("androidx.core:core-ktx:1.16.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.9.2")
+    implementation("androidx.compose.ui:ui:1.8.3")
+    implementation("androidx.compose.material3:material3:1.3.2")
+    implementation("androidx.activity:activity-compose:1.10.1")
+    implementation("androidx.navigation:navigation-compose:2.9.3")
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
     implementation("androidx.appcompat:appcompat:1.7.1")
 
     testImplementation("junit:junit:4.13.2")

--- a/product-base/android-app/app/src/main/AndroidManifest.xml
+++ b/product-base/android-app/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     <application
         android:theme="@style/Theme.AppCompat.DayNight.NoActionBar"
         android:allowBackup="true"
-        android:label="LucraAndroidApp"
+        android:label="RNG"
         android:networkSecurityConfig="@xml/network_security_config"
         android:usesCleartextTraffic="true"
         android:supportsRtl="true">

--- a/product-base/android-app/app/src/main/java/com/lucra/android/MainActivity.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/MainActivity.kt
@@ -11,6 +11,8 @@ import com.lucra.android.navigation.AppNavHost
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Restore any previously logged in user before building the UI
+        UserManager.init(applicationContext)
         setContent {
             MaterialTheme {
                 Surface {

--- a/product-base/android-app/app/src/main/java/com/lucra/android/UserManager.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/UserManager.kt
@@ -1,9 +1,50 @@
 package com.lucra.android
 
+import android.content.Context
+import android.content.SharedPreferences
 import androidx.compose.runtime.mutableStateOf
+import com.google.gson.Gson
 import com.lucra.android.api.User
 
+/**
+ * Manages the logged in user for the app. The user is persisted to
+ * [SharedPreferences] so that the login state is retained between launches.
+ */
 object UserManager {
+    private const val PREFS_NAME = "lucra_prefs"
+    private const val KEY_USER = "user"
+
+    private lateinit var prefs: SharedPreferences
+    private val gson = Gson()
+
     var currentUser = mutableStateOf<User?>(null)
+        private set
+
+    /** Initialise the manager and restore any previously stored user. */
+    fun init(context: Context) {
+        prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val userJson = prefs.getString(KEY_USER, null)
+        if (userJson != null) {
+            runCatching {
+                gson.fromJson(userJson, User::class.java)
+            }.onSuccess { restored ->
+                currentUser.value = restored
+            }
+        }
+    }
+
+    /** Persist the user information and mark as logged in. */
+    fun setUser(user: User) {
+        currentUser.value = user
+        prefs.edit().putString(KEY_USER, gson.toJson(user)).apply()
+    }
+
+    /** Clear any stored user and logout. */
+    fun clearUser() {
+        currentUser.value = null
+        prefs.edit().remove(KEY_USER).apply()
+    }
+
     fun isLoggedIn(): Boolean = currentUser.value != null
 }
+

--- a/product-base/android-app/app/src/main/java/com/lucra/android/navigation/AppNavHost.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/navigation/AppNavHost.kt
@@ -10,6 +10,7 @@ import com.lucra.android.ui.screens.HistoryScreen
 import com.lucra.android.ui.screens.LoginScreen
 import com.lucra.android.ui.screens.ProfileScreen
 import com.lucra.android.ui.screens.SignupScreen
+import com.lucra.android.ui.screens.UpdateProfileScreen
 
 @Composable
 fun AppNavHost(navController: NavHostController) {
@@ -22,5 +23,6 @@ fun AppNavHost(navController: NavHostController) {
         composable("dashboard") { DashboardScreen(navController) }
         composable("history") { HistoryScreen(navController) }
         composable("profile") { ProfileScreen(navController) }
+        composable("updateProfile") { UpdateProfileScreen(navController) }
     }
 }

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/DashboardScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/DashboardScreen.kt
@@ -9,10 +9,10 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
-import androidx.compose.material3.icons.Icons
-import androidx.compose.material3.icons.filled.Casino
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -92,7 +92,7 @@ fun DashboardScreen(navController: NavController) {
                     },
                 contentAlignment = Alignment.Center
             ) {
-                Icon(Icons.Filled.Casino, contentDescription = "Generate")
+                Icon(Icons.Filled.Refresh, contentDescription = "Generate")
             }
             Spacer(modifier = Modifier.height(24.dp))
             if (targetNumber != null) {

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/DashboardScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/DashboardScreen.kt
@@ -1,11 +1,14 @@
 package com.lucra.android.ui.screens
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.lucra.android.UserManager
@@ -23,10 +26,32 @@ fun DashboardScreen(navController: NavController) {
         return
     }
 
-    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                Brush.verticalGradient(
+                    listOf(
+                        Color(0xFF4F46E5),
+                        Color(0xFF8B5CF6),
+                        Color(0xFFEC4899)
+                    )
+                )
+            )
+            .padding(16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
             TextButton(onClick = { navController.navigate("profile") }) { Text("Profile") }
             TextButton(onClick = { navController.navigate("history") }) { Text("History") }
+            TextButton(onClick = {
+                UserManager.clearUser()
+                navController.navigate("login") {
+                    popUpTo("dashboard") { inclusive = true }
+                }
+            }) { Text("Logout") }
         }
         Spacer(modifier = Modifier.height(32.dp))
         currentNumber?.let { Text("Latest number: $it") }

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/HistoryScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/HistoryScreen.kt
@@ -5,14 +5,16 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Divider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
+import androidx.compose.material3.icons.Icons
+import androidx.compose.material3.icons.filled.ArrowBack
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.lucra.android.UserManager
 import com.lucra.android.api.ApiClient
@@ -54,7 +56,12 @@ fun HistoryScreen(navController: NavController) {
             )
             .padding(16.dp)
     ) {
-        TextButton(onClick = { navController.popBackStack() }) { Text("<", color = Color.White, fontSize = 24.sp) }
+        IconButton(
+            onClick = { navController.popBackStack() },
+            modifier = Modifier.size(48.dp)
+        ) {
+            Icon(Icons.Filled.ArrowBack, contentDescription = "Back", tint = Color.White)
+        }
         Spacer(modifier = Modifier.height(16.dp))
         LazyColumn {
             items(items) { item ->

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/HistoryScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/HistoryScreen.kt
@@ -1,5 +1,6 @@
 package com.lucra.android.ui.screens
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -8,6 +9,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.lucra.android.UserManager
@@ -36,7 +39,20 @@ fun HistoryScreen(navController: NavController) {
         }
     }
 
-    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                Brush.verticalGradient(
+                    listOf(
+                        Color(0xFF6366F1),
+                        Color(0xFF8B5CF6),
+                        Color(0xFFEC4899)
+                    )
+                )
+            )
+            .padding(16.dp)
+    ) {
         TextButton(onClick = { navController.popBackStack() }) { Text("Back") }
         Spacer(modifier = Modifier.height(16.dp))
         LazyColumn {

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/HistoryScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/HistoryScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.lucra.android.UserManager
 import com.lucra.android.api.ApiClient
@@ -53,7 +54,7 @@ fun HistoryScreen(navController: NavController) {
             )
             .padding(16.dp)
     ) {
-        TextButton(onClick = { navController.popBackStack() }) { Text("Back") }
+        TextButton(onClick = { navController.popBackStack() }) { Text("<", color = Color.White, fontSize = 24.sp) }
         Spacer(modifier = Modifier.height(16.dp))
         LazyColumn {
             items(items) { item ->

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/HistoryScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/HistoryScreen.kt
@@ -1,16 +1,27 @@
 package com.lucra.android.ui.screens
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
-import androidx.compose.material3.icons.Icons
-import androidx.compose.material3.icons.filled.ArrowBack
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -60,7 +71,11 @@ fun HistoryScreen(navController: NavController) {
             onClick = { navController.popBackStack() },
             modifier = Modifier.size(48.dp)
         ) {
-            Icon(Icons.Filled.ArrowBack, contentDescription = "Back", tint = Color.White)
+            Icon(
+                Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "Back",
+                tint = Color.White
+            )
         }
         Spacer(modifier = Modifier.height(16.dp))
         LazyColumn {

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/LoginScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/LoginScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/LoginScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/LoginScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -35,9 +36,11 @@ import androidx.compose.ui.platform.LocalAutofill
 import androidx.compose.ui.platform.LocalAutofillTree
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.lucra.android.UserManager
 import com.lucra.android.api.ApiClient
@@ -76,42 +79,47 @@ fun LoginScreen(navController: NavController) {
     ) {
         Column(
             modifier = Modifier
-                .verticalScroll(rememberScrollState())
-                .fillMaxSize(),
+                .align(Alignment.Center)
+                .verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
-        TextField(
-            value = email,
-            onValueChange = {
-                email = it
-            },
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
-            modifier = Modifier
-                .focusRequester(focusRequester)
-                .onGloballyPositioned {
-                    autofillNode.boundingBox = it.boundsInWindow()
-                }
-                .onFocusChanged { focusState ->
-                    if (focusState.isFocused) {
-                        autofill?.requestAutofillForNode(autofillNode)
-                    } else {
-                        autofill?.cancelAutofillForNode(autofillNode)
-                    }
+            TextField(
+                value = email,
+                onValueChange = {
+                    email = it
                 },
-            singleLine = true,
-            label = { Text("Email") }
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        TextField(
-            value = password,
-            onValueChange = { password = it },
-            label = { Text("Password") },
-            visualTransformation = PasswordVisualTransformation()
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        Button(onClick = {
-            scope.launch {
-                try {
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+                modifier = Modifier
+                    .focusRequester(focusRequester)
+                    .onGloballyPositioned {
+                        autofillNode.boundingBox = it.boundsInWindow()
+                    }
+                    .onFocusChanged { focusState ->
+                        if (focusState.isFocused) {
+                            autofill?.requestAutofillForNode(autofillNode)
+                        } else {
+                            autofill?.cancelAutofillForNode(autofillNode)
+                        }
+                    }
+                    .fillMaxWidth(),
+                singleLine = true,
+                label = { Text("Email") },
+                shape = RoundedCornerShape(50)
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            TextField(
+                value = password,
+                onValueChange = { password = it },
+                label = { Text("Password") },
+                visualTransformation = PasswordVisualTransformation(),
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(50)
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = {
+                scope.launch {
+                    try {
                     val user = ApiClient.service.login(LoginRequest(email, password))
                     UserManager.setUser(user)
                     navController.navigate("dashboard") {
@@ -121,8 +129,8 @@ fun LoginScreen(navController: NavController) {
                     Log.e("LoginScreen", "Login failed", e)
                 }
             }
-        }) { Text("Login") }
-        TextButton(onClick = { navController.navigate("signup") }) { Text("Sign Up") }
+            }) { Text("Login", fontSize = 18.sp) }
+            TextButton(onClick = { navController.navigate("signup") }) { Text("Sign Up", fontSize = 16.sp) }
         }
     }
 }

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/LoginScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/LoginScreen.kt
@@ -1,7 +1,9 @@
 package com.lucra.android.ui.screens
 
 import android.util.Log
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -31,6 +33,8 @@ import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalAutofill
 import androidx.compose.ui.platform.LocalAutofillTree
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
@@ -56,12 +60,26 @@ fun LoginScreen(navController: NavController) {
         )
     }
     LocalAutofillTree.current += autofillNode
-    Column(
+    Box(
         modifier = Modifier
-            .verticalScroll(rememberScrollState())
-            .padding(16.dp),
-        verticalArrangement = Arrangement.Top
+            .fillMaxSize()
+            .background(
+                brush = Brush.verticalGradient(
+                    colors = listOf(
+                        Color(0xFF8B5CF6),
+                        Color(0xFFEC4899),
+                        Color(0xFFF43F5E)
+                    )
+                )
+            )
+            .padding(16.dp)
     ) {
+        Column(
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+                .fillMaxSize(),
+            verticalArrangement = Arrangement.Center
+        ) {
         TextField(
             value = email,
             onValueChange = {
@@ -95,7 +113,7 @@ fun LoginScreen(navController: NavController) {
             scope.launch {
                 try {
                     val user = ApiClient.service.login(LoginRequest(email, password))
-                    UserManager.currentUser.value = user
+                    UserManager.setUser(user)
                     navController.navigate("dashboard") {
                         popUpTo("login") { inclusive = true }
                     }
@@ -105,5 +123,6 @@ fun LoginScreen(navController: NavController) {
             }
         }) { Text("Login") }
         TextButton(onClick = { navController.navigate("signup") }) { Text("Sign Up") }
+        }
     }
 }

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/ProfileScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/ProfileScreen.kt
@@ -1,5 +1,6 @@
 package com.lucra.android.ui.screens
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
@@ -7,6 +8,8 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.lucra.android.UserManager
@@ -28,7 +31,20 @@ fun ProfileScreen(navController: NavController) {
     var fullName by remember { mutableStateOf(user.full_name) }
     var email by remember { mutableStateOf(user.email) }
 
-    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                Brush.verticalGradient(
+                    listOf(
+                        Color(0xFF3B82F6),
+                        Color(0xFF8B5CF6),
+                        Color(0xFFEC4899)
+                    )
+                )
+            )
+            .padding(16.dp)
+    ) {
         TextButton(onClick = { navController.popBackStack() }) { Text("Back") }
         Spacer(modifier = Modifier.height(16.dp))
         TextField(value = fullName, onValueChange = { fullName = it }, label = { Text("Full Name") })
@@ -42,11 +58,18 @@ fun ProfileScreen(navController: NavController) {
                         user.id,
                         UpdateProfileRequest(fullName, email, user.address, user.city, user.state, user.zip_code, user.birthday)
                     )
-                    userState.value = updated
+                    UserManager.setUser(updated)
                     navController.popBackStack()
                 } catch (e: Exception) {
                 }
             }
         }) { Text("Save") }
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = {
+            UserManager.clearUser()
+            navController.navigate("login") {
+                popUpTo("dashboard") { inclusive = true }
+            }
+        }) { Text("Logout") }
     }
 }

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/ProfileScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/ProfileScreen.kt
@@ -3,8 +3,11 @@ package com.lucra.android.ui.screens
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
+import androidx.compose.material3.icons.Icons
+import androidx.compose.material3.icons.filled.ArrowBack
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -52,11 +55,13 @@ fun ProfileScreen(navController: NavController) {
             )
             .padding(16.dp)
     ) {
-        TextButton(
+        IconButton(
             onClick = { navController.popBackStack() },
-            modifier = Modifier.align(Alignment.TopStart)
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .size(48.dp)
         ) {
-            Text("<", color = Color.White, fontSize = 24.sp)
+            Icon(Icons.Filled.ArrowBack, contentDescription = "Back", tint = Color.White)
         }
 
         Column(

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/ProfileScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/ProfileScreen.kt
@@ -1,14 +1,26 @@
 package com.lucra.android.ui.screens
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
-import androidx.compose.material3.icons.Icons
-import androidx.compose.material3.icons.filled.ArrowBack
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -61,7 +73,11 @@ fun ProfileScreen(navController: NavController) {
                 .align(Alignment.TopStart)
                 .size(48.dp)
         ) {
-            Icon(Icons.Filled.ArrowBack, contentDescription = "Back", tint = Color.White)
+            Icon(
+                Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "Back",
+                tint = Color.White
+            )
         }
 
         Column(

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/SignupScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/SignupScreen.kt
@@ -1,11 +1,14 @@
 package com.lucra.android.ui.screens
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -20,29 +23,44 @@ fun SignupScreen(navController: NavController) {
     var password by remember { mutableStateOf("") }
     val scope = rememberCoroutineScope()
 
-    Column(
-        modifier = Modifier.fillMaxSize().padding(16.dp),
-        verticalArrangement = Arrangement.Center
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                Brush.verticalGradient(
+                    listOf(
+                        Color(0xFF8B5CF6),
+                        Color(0xFFEC4899),
+                        Color(0xFFF43F5E)
+                    )
+                )
+            )
+            .padding(16.dp)
     ) {
-        TextField(value = fullName, onValueChange = { fullName = it }, label = { Text("Full Name") })
-        Spacer(modifier = Modifier.height(8.dp))
-        TextField(value = email, onValueChange = { email = it }, label = { Text("Email") })
-        Spacer(modifier = Modifier.height(8.dp))
-        TextField(
-            value = password,
-            onValueChange = { password = it },
-            label = { Text("Password") },
-            visualTransformation = PasswordVisualTransformation()
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        Button(onClick = {
-            scope.launch {
-                try {
-                    ApiClient.service.signup(SignupRequest(fullName, email, password))
-                    navController.popBackStack()
-                } catch (e: Exception) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Center
+        ) {
+            TextField(value = fullName, onValueChange = { fullName = it }, label = { Text("Full Name") })
+            Spacer(modifier = Modifier.height(8.dp))
+            TextField(value = email, onValueChange = { email = it }, label = { Text("Email") })
+            Spacer(modifier = Modifier.height(8.dp))
+            TextField(
+                value = password,
+                onValueChange = { password = it },
+                label = { Text("Password") },
+                visualTransformation = PasswordVisualTransformation()
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = {
+                scope.launch {
+                    try {
+                        ApiClient.service.signup(SignupRequest(fullName, email, password))
+                        navController.popBackStack()
+                    } catch (e: Exception) {
+                    }
                 }
-            }
-        }) { Text("Create Account") }
+            }) { Text("Create Account") }
+        }
     }
 }

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/SignupScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/SignupScreen.kt
@@ -21,6 +21,11 @@ fun SignupScreen(navController: NavController) {
     var fullName by remember { mutableStateOf("") }
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
+    var address by remember { mutableStateOf("") }
+    var city by remember { mutableStateOf("") }
+    var state by remember { mutableStateOf("") }
+    var zip by remember { mutableStateOf("") }
+    var birthday by remember { mutableStateOf("") }
     val scope = rememberCoroutineScope()
 
     Box(
@@ -45,17 +50,38 @@ fun SignupScreen(navController: NavController) {
             Spacer(modifier = Modifier.height(8.dp))
             TextField(value = email, onValueChange = { email = it }, label = { Text("Email") })
             Spacer(modifier = Modifier.height(8.dp))
+            TextField(value = address, onValueChange = { address = it }, label = { Text("Address") })
+            Spacer(modifier = Modifier.height(8.dp))
+            TextField(value = city, onValueChange = { city = it }, label = { Text("City") })
+            Spacer(modifier = Modifier.height(8.dp))
+            TextField(value = state, onValueChange = { state = it }, label = { Text("State") })
+            Spacer(modifier = Modifier.height(8.dp))
+            TextField(value = zip, onValueChange = { zip = it }, label = { Text("Zip Code") })
+            Spacer(modifier = Modifier.height(8.dp))
+            TextField(value = birthday, onValueChange = { birthday = it }, label = { Text("Birthday") })
+            Spacer(modifier = Modifier.height(8.dp))
             TextField(
                 value = password,
                 onValueChange = { password = it },
                 label = { Text("Password") },
-                visualTransformation = PasswordVisualTransformation()
+                visualTransformation = PasswordVisualTransformation(),
             )
             Spacer(modifier = Modifier.height(16.dp))
             Button(onClick = {
                 scope.launch {
                     try {
-                        ApiClient.service.signup(SignupRequest(fullName, email, password))
+                        ApiClient.service.signup(
+                            SignupRequest(
+                                full_name = fullName,
+                                email = email,
+                                password = password,
+                                address = address.takeIf { it.isNotBlank() },
+                                city = city.takeIf { it.isNotBlank() },
+                                state = state.takeIf { it.isNotBlank() },
+                                zip_code = zip.takeIf { it.isNotBlank() },
+                                birthday = birthday.takeIf { it.isNotBlank() }
+                            )
+                        )
                         navController.popBackStack()
                     } catch (e: Exception) {
                     }

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/UpdateProfileScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/UpdateProfileScreen.kt
@@ -3,16 +3,18 @@ package com.lucra.android.ui.screens
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
+import androidx.compose.material3.icons.Icons
+import androidx.compose.material3.icons.filled.ArrowBack
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.lucra.android.UserManager
 import com.lucra.android.api.ApiClient
@@ -31,6 +33,11 @@ fun UpdateProfileScreen(navController: NavController) {
 
     var fullName by remember { mutableStateOf(user.full_name) }
     var email by remember { mutableStateOf(user.email) }
+    var address by remember { mutableStateOf(user.address ?: "") }
+    var city by remember { mutableStateOf(user.city ?: "") }
+    var state by remember { mutableStateOf(user.state ?: "") }
+    var zip by remember { mutableStateOf(user.zip_code ?: "") }
+    var birthday by remember { mutableStateOf(user.birthday ?: "") }
 
     Box(
         modifier = Modifier
@@ -44,12 +51,16 @@ fun UpdateProfileScreen(navController: NavController) {
                     )
                 )
             )
-            .padding(16.dp)
+            .padding(16.dp),
     ) {
-        TextButton(
+        IconButton(
             onClick = { navController.popBackStack() },
-            modifier = Modifier.align(Alignment.TopStart)
-        ) { Text("<", color = Color.White, fontSize = 24.sp) }
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .size(48.dp)
+        ) {
+            Icon(Icons.Filled.ArrowBack, contentDescription = "Back", tint = Color.White)
+        }
 
         Column(
             modifier = Modifier.align(Alignment.Center),
@@ -58,13 +69,23 @@ fun UpdateProfileScreen(navController: NavController) {
             TextField(value = fullName, onValueChange = { fullName = it }, label = { Text("Full Name") })
             Spacer(modifier = Modifier.height(8.dp))
             TextField(value = email, onValueChange = { email = it }, label = { Text("Email") })
+            Spacer(modifier = Modifier.height(8.dp))
+            TextField(value = address, onValueChange = { address = it }, label = { Text("Address") })
+            Spacer(modifier = Modifier.height(8.dp))
+            TextField(value = city, onValueChange = { city = it }, label = { Text("City") })
+            Spacer(modifier = Modifier.height(8.dp))
+            TextField(value = state, onValueChange = { state = it }, label = { Text("State") })
+            Spacer(modifier = Modifier.height(8.dp))
+            TextField(value = zip, onValueChange = { zip = it }, label = { Text("Zip Code") })
+            Spacer(modifier = Modifier.height(8.dp))
+            TextField(value = birthday, onValueChange = { birthday = it }, label = { Text("Birthday") })
             Spacer(modifier = Modifier.height(16.dp))
             Button(onClick = {
                 scope.launch {
                     try {
                         val updated = ApiClient.service.updateProfile(
                             user.id,
-                            UpdateProfileRequest(fullName, email, user.address, user.city, user.state, user.zip_code, user.birthday)
+                            UpdateProfileRequest(fullName, email, address, city, state, zip, birthday),
                         )
                         UserManager.setUser(updated)
                         navController.popBackStack()

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/UpdateProfileScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/UpdateProfileScreen.kt
@@ -1,15 +1,27 @@
 package com.lucra.android.ui.screens
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
-import androidx.compose.material3.icons.Icons
-import androidx.compose.material3.icons.filled.ArrowBack
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -59,18 +71,28 @@ fun UpdateProfileScreen(navController: NavController) {
                 .align(Alignment.TopStart)
                 .size(48.dp)
         ) {
-            Icon(Icons.Filled.ArrowBack, contentDescription = "Back", tint = Color.White)
+            Icon(
+                Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "Back",
+                tint = Color.White
+            )
         }
 
         Column(
             modifier = Modifier.align(Alignment.Center),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            TextField(value = fullName, onValueChange = { fullName = it }, label = { Text("Full Name") })
+            TextField(
+                value = fullName,
+                onValueChange = { fullName = it },
+                label = { Text("Full Name") })
             Spacer(modifier = Modifier.height(8.dp))
             TextField(value = email, onValueChange = { email = it }, label = { Text("Email") })
             Spacer(modifier = Modifier.height(8.dp))
-            TextField(value = address, onValueChange = { address = it }, label = { Text("Address") })
+            TextField(
+                value = address,
+                onValueChange = { address = it },
+                label = { Text("Address") })
             Spacer(modifier = Modifier.height(8.dp))
             TextField(value = city, onValueChange = { city = it }, label = { Text("City") })
             Spacer(modifier = Modifier.height(8.dp))
@@ -78,14 +100,25 @@ fun UpdateProfileScreen(navController: NavController) {
             Spacer(modifier = Modifier.height(8.dp))
             TextField(value = zip, onValueChange = { zip = it }, label = { Text("Zip Code") })
             Spacer(modifier = Modifier.height(8.dp))
-            TextField(value = birthday, onValueChange = { birthday = it }, label = { Text("Birthday") })
+            TextField(
+                value = birthday,
+                onValueChange = { birthday = it },
+                label = { Text("Birthday") })
             Spacer(modifier = Modifier.height(16.dp))
             Button(onClick = {
                 scope.launch {
                     try {
                         val updated = ApiClient.service.updateProfile(
                             user.id,
-                            UpdateProfileRequest(fullName, email, address, city, state, zip, birthday),
+                            UpdateProfileRequest(
+                                fullName,
+                                email,
+                                address,
+                                city,
+                                state,
+                                zip,
+                                birthday
+                            ),
                         )
                         UserManager.setUser(updated)
                         navController.popBackStack()


### PR DESCRIPTION
## Summary
- Persist user sessions with SharedPreferences and auto redirect to dashboard
- Add logout flow and gradient-based UI to match web app

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68927c42e340832e93e40eee021ee8d5