### PR TITLE
Fix number animation and history pagination

### DIFF
--- a/product-base/ios-app/RNGApp/Views/HistoryView.swift
+++ b/product-base/ios-app/RNGApp/Views/HistoryView.swift
@@ -2,32 +2,71 @@ import SwiftUI
 
 struct HistoryView: View {
     @EnvironmentObject var session: SessionManager
+    @Environment(\.dismiss) var dismiss
     @State private var numbers: [NumberRecord] = []
+    @State private var page = 1
+    @State private var isLoading = false
+    @State private var hasMore = true
 
     var body: some View {
         ZStack {
             LinearGradient(colors: [.blue, .purple, .pink], startPoint: .topLeading, endPoint: .bottomTrailing)
                 .ignoresSafeArea()
-            List(numbers) { item in
-                HStack {
-                    Text("\(item.value)")
-                    Spacer()
-                    Text(item.created_at)
-                        .font(.caption)
+            List {
+                ForEach(numbers) { item in
+                    HStack {
+                        Text("\(item.value)")
+                        Spacer()
+                        Text(item.created_at)
+                            .font(.caption)
+                    }
+                    .foregroundColor(.white)
+                    .listRowBackground(Color.clear)
+                    .onAppear {
+                        if item.id == numbers.last?.id { loadMore() }
+                    }
                 }
-                .foregroundColor(.white)
+                if isLoading {
+                    ProgressView()
+                        .listRowBackground(Color.clear)
+                }
             }
+            .listStyle(.plain)
             .scrollContentBackground(.hidden)
         }
         .onAppear { load() }
         .navigationTitle("History")
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(action: { dismiss() }) {
+                    Image(systemName: "chevron.left")
+                        .foregroundColor(.white)
+                }
+            }
+        }
     }
 
     func load() {
-        guard let id = session.user?.id else { return }
+        numbers = []
+        page = 1
+        hasMore = true
+        loadMore()
+    }
+
+    func loadMore() {
+        guard !isLoading, hasMore, let id = session.user?.id else { return }
+        isLoading = true
         Task {
-            if let res = try? await APIService.shared.getNumberHistory(page: 1, limit: 25, userId: id) {
-                await MainActor.run { numbers = res.numbers }
+            if let res = try? await APIService.shared.getNumberHistory(page: page, limit: 25, userId: id) {
+                await MainActor.run {
+                    numbers.append(contentsOf: res.numbers)
+                    page += 1
+                    hasMore = res.next != nil
+                    isLoading = false
+                }
+            } else {
+                await MainActor.run { isLoading = false }
             }
         }
     }

--- a/product-base/ios-app/RNGApp/Views/NumberDisplayView.swift
+++ b/product-base/ios-app/RNGApp/Views/NumberDisplayView.swift
@@ -13,6 +13,7 @@ struct NumberDisplayView: View {
             .font(.system(size: 72, weight: .bold))
             .foregroundColor(.white)
             .onChange(of: targetNumber) { _ in start() }
+            .onAppear { start() }
             .onDisappear { timer?.invalidate() }
     }
 
@@ -21,11 +22,10 @@ struct NumberDisplayView: View {
         current = 0
         timer?.invalidate()
         let startDate = Date()
-        let duration: TimeInterval = 5
+        let duration: TimeInterval = 1
         timer = Timer.scheduledTimer(withTimeInterval: 0.02, repeats: true) { t in
             let progress = min(Date().timeIntervalSince(startDate)/duration, 1)
-            let eased = progress * progress * (3 - 2 * progress)
-            current = Int(Double(target) * eased)
+            current = Int(Double(target) * progress)
             if progress >= 1 {
                 t.invalidate()
                 current = target

--- a/product-base/ios-app/RNGApp/Views/NumberDisplayView.swift
+++ b/product-base/ios-app/RNGApp/Views/NumberDisplayView.swift
@@ -12,13 +12,14 @@ struct NumberDisplayView: View {
         Text("\(current)")
             .font(.system(size: 72, weight: .bold))
             .foregroundColor(.white)
-            .onChange(of: targetNumber) { _ in start() }
-            .onAppear { start() }
+            .onChange(of: targetNumber) { newValue in
+                guard let target = newValue else { return }
+                start(target)
+            }
             .onDisappear { timer?.invalidate() }
     }
 
-    func start() {
-        guard let target = targetNumber else { return }
+    private func start(_ target: Int) {
         current = 0
         timer?.invalidate()
         let startDate = Date()

--- a/product-base/ios-app/RNGApp/Views/ProfileView.swift
+++ b/product-base/ios-app/RNGApp/Views/ProfileView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ProfileView: View {
     @EnvironmentObject var session: SessionManager
+    @Environment(\.dismiss) var dismiss
     @State private var stats = Stats(totalNumbersGenerated: 0, bestNumber: 0)
 
     var body: some View {
@@ -10,7 +11,7 @@ struct ProfileView: View {
                 .ignoresSafeArea()
             VStack(spacing: 20) {
                 HStack {
-                    NavigationLink(destination: DashboardView()) {
+                    Button(action: { dismiss() }) {
                         Image(systemName: "arrow.left")
                             .foregroundColor(.white)
                     }
@@ -50,6 +51,7 @@ struct ProfileView: View {
                         .foregroundColor(.white)
                     Button("Logout") {
                         session.logout()
+                        dismiss()
                     }
                     .padding()
                     .background(Color.red)


### PR DESCRIPTION
## Summary
- animate generated numbers to the target quickly
- fix history list visibility, add pagination and a back button
- ensure logout returns to the sign-in screen

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_68927cdda62c832e8fb268c5ca8e793b