### PR TITLE
Adjust top UI padding for full-screen Android app

### DIFF
--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/DashboardScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/DashboardScreen.kt
@@ -59,7 +59,7 @@ fun DashboardScreen(navController: NavController) {
                 )
             )
             .statusBarsPadding()
-            .padding(horizontal = 16.dp, bottom = 16.dp)
+            .padding(end = 16.dp, start = 16.dp, bottom = 16.dp)
     ) {
         Box(
             modifier = Modifier

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/DashboardScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/DashboardScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -57,10 +58,12 @@ fun DashboardScreen(navController: NavController) {
                     )
                 )
             )
-            .padding(16.dp)
+            .statusBarsPadding()
+            .padding(horizontal = 16.dp, bottom = 16.dp)
     ) {
         Box(
             modifier = Modifier
+                .padding(top = 16.dp)
                 .size(48.dp)
                 .clip(CircleShape)
                 .background(Color.White.copy(alpha = 0.3f))

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/HistoryScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/HistoryScreen.kt
@@ -67,7 +67,7 @@ fun HistoryScreen(navController: NavController) {
                 )
             )
             .statusBarsPadding()
-            .padding(horizontal = 16.dp, bottom = 16.dp)
+            .padding(end = 16.dp, start = 16.dp, bottom = 16.dp)
     ) {
         IconButton(
             onClick = { navController.popBackStack() },

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/HistoryScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/HistoryScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -65,11 +66,14 @@ fun HistoryScreen(navController: NavController) {
                     )
                 )
             )
-            .padding(16.dp)
+            .statusBarsPadding()
+            .padding(horizontal = 16.dp, bottom = 16.dp)
     ) {
         IconButton(
             onClick = { navController.popBackStack() },
-            modifier = Modifier.size(48.dp)
+            modifier = Modifier
+                .padding(top = 16.dp)
+                .size(48.dp)
         ) {
             Icon(
                 Icons.AutoMirrored.Filled.ArrowBack,

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/ProfileScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/ProfileScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
@@ -65,11 +66,13 @@ fun ProfileScreen(navController: NavController) {
                     )
                 )
             )
-            .padding(16.dp)
+            .statusBarsPadding()
+            .padding(horizontal = 16.dp, bottom = 16.dp)
     ) {
         IconButton(
             onClick = { navController.popBackStack() },
             modifier = Modifier
+                .padding(top = 16.dp)
                 .align(Alignment.TopStart)
                 .size(48.dp)
         ) {

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/ProfileScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/ProfileScreen.kt
@@ -67,7 +67,7 @@ fun ProfileScreen(navController: NavController) {
                 )
             )
             .statusBarsPadding()
-            .padding(horizontal = 16.dp, bottom = 16.dp)
+            .padding(end = 16.dp, start = 16.dp, bottom = 16.dp)
     ) {
         IconButton(
             onClick = { navController.popBackStack() },

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/UpdateProfileScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/UpdateProfileScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
@@ -63,11 +64,13 @@ fun UpdateProfileScreen(navController: NavController) {
                     )
                 )
             )
-            .padding(16.dp),
+            .statusBarsPadding()
+            .padding(horizontal = 16.dp, bottom = 16.dp),
     ) {
         IconButton(
             onClick = { navController.popBackStack() },
             modifier = Modifier
+                .padding(top = 16.dp)
                 .align(Alignment.TopStart)
                 .size(48.dp)
         ) {

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/UpdateProfileScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/UpdateProfileScreen.kt
@@ -65,7 +65,7 @@ fun UpdateProfileScreen(navController: NavController) {
                 )
             )
             .statusBarsPadding()
-            .padding(horizontal = 16.dp, bottom = 16.dp),
+            .padding(end = 16.dp, start = 16.dp, bottom = 16.dp),
     ) {
         IconButton(
             onClick = { navController.popBackStack() },


### PR DESCRIPTION
## Summary
- ensure full-screen dashboard profile button respects status bar with additional top padding
- offset profile, history, and update-profile back buttons from device nav bar

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689369f478cc832e88e689788c2065dc