### PR TITLE
Align Android profile screen with web layout

### DIFF
--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/ProfileScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/ProfileScreen.kt
@@ -1,15 +1,22 @@
 package com.lucra.android.ui.screens
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -23,6 +30,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -67,33 +75,106 @@ fun ProfileScreen(navController: NavController) {
             )
             .padding(16.dp)
     ) {
-        IconButton(
-            onClick = { navController.popBackStack() },
+        Row(
             modifier = Modifier
-                .align(Alignment.TopStart)
-                .size(48.dp)
+                .fillMaxWidth()
+                .align(Alignment.TopCenter),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            Icon(
-                Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = "Back",
-                tint = Color.White
-            )
+            IconButton(onClick = { navController.popBackStack() }) {
+                Icon(
+                    Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Back",
+                    tint = Color.White
+                )
+            }
+            Text("Profile", color = Color.White, fontSize = 24.sp)
+            Spacer(modifier = Modifier.width(48.dp))
         }
 
         Column(
-            modifier = Modifier.align(Alignment.Center),
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .fillMaxWidth()
+                .padding(top = 96.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            Box(
+                modifier = Modifier
+                    .size(96.dp)
+                    .clip(CircleShape)
+                    .background(
+                        Brush.linearGradient(
+                            listOf(
+                                Color(0xFF8B5CF6),
+                                Color(0xFFEC4899)
+                            )
+                        )
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    Icons.Filled.Person,
+                    contentDescription = "Avatar",
+                    tint = Color.White,
+                    modifier = Modifier.size(48.dp)
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
             Text(user.full_name, color = Color.White, fontSize = 32.sp)
-            Spacer(modifier = Modifier.height(16.dp))
-            Text(
-                "Numbers Generated: ${stats?.totalNumbersGenerated ?: 0}",
-                color = Color.White
-            )
-            Text(
-                "Best Number: ${stats?.bestNumber ?: 0}",
-                color = Color.White
-            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(
+                            Brush.horizontalGradient(
+                                listOf(
+                                    Color(0xFF3B82F6),
+                                    Color(0xFF8B5CF6)
+                                )
+                            )
+                        )
+                        .padding(vertical = 16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        "${stats?.totalNumbersGenerated ?: 0}",
+                        color = Color.White,
+                        fontSize = 24.sp
+                    )
+                    Text("Numbers Generated", color = Color.White, fontSize = 12.sp)
+                }
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(
+                            Brush.horizontalGradient(
+                                listOf(
+                                    Color(0xFF22C55E),
+                                    Color(0xFF10B981)
+                                )
+                            )
+                        )
+                        .padding(vertical = 16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        "${stats?.bestNumber ?: 0}",
+                        color = Color.White,
+                        fontSize = 20.sp
+                    )
+                    Text("Best Number", color = Color.White, fontSize = 12.sp)
+                }
+            }
             Spacer(modifier = Modifier.height(24.dp))
             Button(onClick = { navController.navigate("history") }) { Text("History") }
             Spacer(modifier = Modifier.height(8.dp))


### PR DESCRIPTION
## Summary
- Rework Android profile screen to include header, avatar, and stat cards like the web app

## Testing
- `./gradlew :app:assembleDebug` *(fails: missing Android SDK packages/licences)*

------
https://chatgpt.com/codex/tasks/task_e_68936c5b3270832e81e31326aa62b9cd