### PR TITLE
feat: unify color themes across apps

### DIFF
--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/DashboardScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/DashboardScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import com.lucra.android.ui.theme.PrimaryColor
+import com.lucra.android.ui.theme.SecondaryColor
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -57,11 +59,7 @@ fun DashboardScreen(navController: NavController) {
             .fillMaxSize()
             .background(
                 Brush.verticalGradient(
-                    listOf(
-                        Color(0xFF4F46E5),
-                        Color(0xFF8B5CF6),
-                        Color(0xFFEC4899)
-                    )
+                    listOf(PrimaryColor, SecondaryColor)
                 )
             )
             .statusBarsPadding()
@@ -88,7 +86,9 @@ fun DashboardScreen(navController: NavController) {
                 modifier = Modifier
                     .size(120.dp)
                     .clip(CircleShape)
-                    .background(Color.White)
+                    .background(
+                        Brush.horizontalGradient(listOf(PrimaryColor, SecondaryColor))
+                    )
                     .clickable {
                         scope.launch {
                             try {
@@ -100,7 +100,7 @@ fun DashboardScreen(navController: NavController) {
                     },
                 contentAlignment = Alignment.Center
             ) {
-                Icon(Icons.Filled.Refresh, contentDescription = "Generate")
+                Icon(Icons.Filled.Refresh, contentDescription = "Generate", tint = Color.White)
             }
             Spacer(modifier = Modifier.height(24.dp))
             if (targetNumber != null) {

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/HistoryScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/HistoryScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import com.lucra.android.ui.theme.PrimaryColor
+import com.lucra.android.ui.theme.SecondaryColor
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.lucra.android.UserManager
@@ -59,11 +61,7 @@ fun HistoryScreen(navController: NavController) {
             .fillMaxSize()
             .background(
                 Brush.verticalGradient(
-                    listOf(
-                        Color(0xFF6366F1),
-                        Color(0xFF8B5CF6),
-                        Color(0xFFEC4899)
-                    )
+                    listOf(PrimaryColor, SecondaryColor)
                 )
             )
             .statusBarsPadding()

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/LoginScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/LoginScreen.kt
@@ -37,6 +37,9 @@ import androidx.compose.ui.platform.LocalAutofill
 import androidx.compose.ui.platform.LocalAutofillTree
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.material3.ButtonDefaults
+import com.lucra.android.ui.theme.PrimaryColor
+import com.lucra.android.ui.theme.SecondaryColor
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -69,11 +72,7 @@ fun LoginScreen(navController: NavController) {
             .fillMaxSize()
             .background(
                 brush = Brush.verticalGradient(
-                    colors = listOf(
-                        Color(0xFF8B5CF6),
-                        Color(0xFFEC4899),
-                        Color(0xFFF43F5E)
-                    )
+                    colors = listOf(PrimaryColor, SecondaryColor)
                 )
             )
             .padding(16.dp)
@@ -130,7 +129,15 @@ fun LoginScreen(navController: NavController) {
                     Log.e("LoginScreen", "Login failed", e)
                 }
             }
-            }) { Text("Login", fontSize = 18.sp) }
+            },
+            colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent, contentColor = Color.White),
+            modifier = Modifier
+                .background(
+                    brush = Brush.horizontalGradient(listOf(PrimaryColor, SecondaryColor)),
+                    shape = RoundedCornerShape(50)
+                )
+                .fillMaxWidth()
+            ) { Text("Login", fontSize = 18.sp) }
             TextButton(onClick = { navController.navigate("signup") }) { Text("Sign Up", fontSize = 16.sp) }
         }
     }

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/ProfileScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/ProfileScreen.kt
@@ -34,6 +34,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.material3.ButtonDefaults
+import com.lucra.android.ui.theme.PrimaryColor
+import com.lucra.android.ui.theme.SecondaryColor
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
@@ -67,11 +70,7 @@ fun ProfileScreen(navController: NavController) {
             .fillMaxSize()
             .background(
                 Brush.verticalGradient(
-                    listOf(
-                        Color(0xFF3B82F6),
-                        Color(0xFF8B5CF6),
-                        Color(0xFFEC4899)
-                    )
+                    listOf(PrimaryColor, SecondaryColor)
                 )
             )
             .statusBarsPadding()
@@ -108,10 +107,7 @@ fun ProfileScreen(navController: NavController) {
                     .clip(CircleShape)
                     .background(
                         Brush.linearGradient(
-                            listOf(
-                                Color(0xFF8B5CF6),
-                                Color(0xFFEC4899)
-                            )
+                            listOf(PrimaryColor, SecondaryColor)
                         )
                     ),
                 contentAlignment = Alignment.Center
@@ -138,10 +134,7 @@ fun ProfileScreen(navController: NavController) {
                         .clip(RoundedCornerShape(16.dp))
                         .background(
                             Brush.horizontalGradient(
-                                listOf(
-                                    Color(0xFF3B82F6),
-                                    Color(0xFF8B5CF6)
-                                )
+                                listOf(PrimaryColor, SecondaryColor)
                             )
                         )
                         .padding(vertical = 16.dp),
@@ -160,10 +153,7 @@ fun ProfileScreen(navController: NavController) {
                         .clip(RoundedCornerShape(16.dp))
                         .background(
                             Brush.horizontalGradient(
-                                listOf(
-                                    Color(0xFF22C55E),
-                                    Color(0xFF10B981)
-                                )
+                                listOf(PrimaryColor, SecondaryColor)
                             )
                         )
                         .padding(vertical = 16.dp),
@@ -178,16 +168,43 @@ fun ProfileScreen(navController: NavController) {
                 }
             }
             Spacer(modifier = Modifier.height(24.dp))
-            Button(onClick = { navController.navigate("history") }) { Text("History") }
+            Button(
+                onClick = { navController.navigate("history") },
+                colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent, contentColor = Color.White),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        Brush.horizontalGradient(listOf(PrimaryColor, SecondaryColor)),
+                        shape = RoundedCornerShape(50)
+                    )
+            ) { Text("History") }
             Spacer(modifier = Modifier.height(8.dp))
-            Button(onClick = { navController.navigate("updateProfile") }) { Text("Update Profile") }
+            Button(
+                onClick = { navController.navigate("updateProfile") },
+                colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent, contentColor = Color.White),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        Brush.horizontalGradient(listOf(PrimaryColor, SecondaryColor)),
+                        shape = RoundedCornerShape(50)
+                    )
+            ) { Text("Update Profile") }
             Spacer(modifier = Modifier.height(8.dp))
-            Button(onClick = {
+            Button(
+                onClick = {
                 UserManager.clearUser()
                 navController.navigate("login") {
                     popUpTo("dashboard") { inclusive = true }
                 }
-            }) { Text("Logout") }
+            },
+                colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent, contentColor = Color.White),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        Brush.horizontalGradient(listOf(PrimaryColor, SecondaryColor)),
+                        shape = RoundedCornerShape(50)
+                    )
+            ) { Text("Logout") }
         }
     }
 }

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/SignupScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/SignupScreen.kt
@@ -2,6 +2,7 @@ package com.lucra.android.ui.screens
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -9,6 +10,9 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.material3.ButtonDefaults
+import com.lucra.android.ui.theme.PrimaryColor
+import com.lucra.android.ui.theme.SecondaryColor
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -33,11 +37,7 @@ fun SignupScreen(navController: NavController) {
             .fillMaxSize()
             .background(
                 Brush.verticalGradient(
-                    listOf(
-                        Color(0xFF8B5CF6),
-                        Color(0xFFEC4899),
-                        Color(0xFFF43F5E)
-                    )
+                    listOf(PrimaryColor, SecondaryColor)
                 )
             )
             .padding(16.dp)
@@ -67,7 +67,8 @@ fun SignupScreen(navController: NavController) {
                 visualTransformation = PasswordVisualTransformation(),
             )
             Spacer(modifier = Modifier.height(16.dp))
-            Button(onClick = {
+            Button(
+                onClick = {
                 scope.launch {
                     try {
                         ApiClient.service.signup(
@@ -86,7 +87,15 @@ fun SignupScreen(navController: NavController) {
                     } catch (e: Exception) {
                     }
                 }
-            }) { Text("Create Account") }
+                },
+                colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent, contentColor = Color.White),
+                modifier = Modifier
+                    .background(
+                        Brush.horizontalGradient(listOf(PrimaryColor, SecondaryColor)),
+                        shape = RoundedCornerShape(50)
+                    )
+                    .fillMaxWidth()
+            ) { Text("Create Account") }
         }
     }
 }

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/UpdateProfileScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/UpdateProfileScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
@@ -27,6 +28,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.material3.ButtonDefaults
+import com.lucra.android.ui.theme.PrimaryColor
+import com.lucra.android.ui.theme.SecondaryColor
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.lucra.android.UserManager
@@ -57,11 +61,7 @@ fun UpdateProfileScreen(navController: NavController) {
             .fillMaxSize()
             .background(
                 Brush.verticalGradient(
-                    listOf(
-                        Color(0xFF3B82F6),
-                        Color(0xFF8B5CF6),
-                        Color(0xFFEC4899)
-                    )
+                    listOf(PrimaryColor, SecondaryColor)
                 )
             )
             .statusBarsPadding()
@@ -108,7 +108,8 @@ fun UpdateProfileScreen(navController: NavController) {
                 onValueChange = { birthday = it },
                 label = { Text("Birthday") })
             Spacer(modifier = Modifier.height(16.dp))
-            Button(onClick = {
+            Button(
+                onClick = {
                 scope.launch {
                     try {
                         val updated = ApiClient.service.updateProfile(
@@ -128,7 +129,14 @@ fun UpdateProfileScreen(navController: NavController) {
                     } catch (_: Exception) {
                     }
                 }
-            }) { Text("Save") }
+                },
+                colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent, contentColor = Color.White),
+                modifier = Modifier
+                    .background(
+                        Brush.horizontalGradient(listOf(PrimaryColor, SecondaryColor)),
+                        shape = RoundedCornerShape(50)
+                    )
+            ) { Text("Save") }
         }
     }
 }

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/theme/Colors.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/theme/Colors.kt
@@ -1,0 +1,6 @@
+package com.lucra.android.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val PrimaryColor = Color(0xFFEC4899)
+val SecondaryColor = Color(0xFF818CF8)

--- a/product-base/ios-app/RNGApp/Theme.swift
+++ b/product-base/ios-app/RNGApp/Theme.swift
@@ -1,0 +1,6 @@
+import SwiftUI
+
+extension Color {
+    static let primaryColor = Color(red: 236/255, green: 72/255, blue: 153/255)
+    static let secondaryColor = Color(red: 129/255, green: 140/255, blue: 248/255)
+}

--- a/product-base/ios-app/RNGApp/Views/DashboardView.swift
+++ b/product-base/ios-app/RNGApp/Views/DashboardView.swift
@@ -8,7 +8,7 @@ struct DashboardView: View {
 
     var body: some View {
         ZStack {
-            LinearGradient(colors: [.indigo, .purple, .pink], startPoint: .topLeading, endPoint: .bottomTrailing)
+            LinearGradient(colors: [.primaryColor, .secondaryColor], startPoint: .topLeading, endPoint: .bottomTrailing)
                 .ignoresSafeArea()
             VStack {
                 HStack {
@@ -48,7 +48,7 @@ struct DashboardView: View {
                     Text("Generate").bold()
                 }
                 .frame(width: 120, height: 120)
-                .background(LinearGradient(colors: [.yellow, .orange], startPoint: .topLeading, endPoint: .bottomTrailing))
+                .background(LinearGradient(colors: [.primaryColor, .secondaryColor], startPoint: .leading, endPoint: .trailing))
                 .foregroundColor(.white)
                 .clipShape(Circle())
                 .padding(.bottom, 40)

--- a/product-base/ios-app/RNGApp/Views/HistoryView.swift
+++ b/product-base/ios-app/RNGApp/Views/HistoryView.swift
@@ -10,7 +10,7 @@ struct HistoryView: View {
 
     var body: some View {
         ZStack {
-            LinearGradient(colors: [.blue, .purple, .pink], startPoint: .topLeading, endPoint: .bottomTrailing)
+            LinearGradient(colors: [.primaryColor, .secondaryColor], startPoint: .topLeading, endPoint: .bottomTrailing)
                 .ignoresSafeArea()
             List {
                 ForEach(numbers) { item in

--- a/product-base/ios-app/RNGApp/Views/LoginView.swift
+++ b/product-base/ios-app/RNGApp/Views/LoginView.swift
@@ -8,7 +8,7 @@ struct LoginView: View {
 
     var body: some View {
         ZStack {
-            LinearGradient(colors: [.purple, .pink, .red], startPoint: .topLeading, endPoint: .bottomTrailing)
+            LinearGradient(colors: [.primaryColor, .secondaryColor], startPoint: .topLeading, endPoint: .bottomTrailing)
                 .ignoresSafeArea()
             VStack(spacing: 20) {
                 Text("RNG")
@@ -35,7 +35,7 @@ struct LoginView: View {
                 }
                 .frame(maxWidth: .infinity)
                 .padding()
-                .background(Color.purple)
+                .background(LinearGradient(colors: [.primaryColor, .secondaryColor], startPoint: .leading, endPoint: .trailing))
                 .foregroundColor(.white)
                 .cornerRadius(16)
                 NavigationLink("Sign up", destination: SignupView())

--- a/product-base/ios-app/RNGApp/Views/ProfileView.swift
+++ b/product-base/ios-app/RNGApp/Views/ProfileView.swift
@@ -7,7 +7,7 @@ struct ProfileView: View {
 
     var body: some View {
         ZStack {
-            LinearGradient(colors: [.blue, .purple, .pink], startPoint: .topLeading, endPoint: .bottomTrailing)
+            LinearGradient(colors: [.primaryColor, .secondaryColor], startPoint: .topLeading, endPoint: .bottomTrailing)
                 .ignoresSafeArea()
             VStack(spacing: 20) {
                 HStack {
@@ -46,7 +46,7 @@ struct ProfileView: View {
                     }
                     NavigationLink("Number History", destination: HistoryView())
                         .padding()
-                        .background(Color.blue.opacity(0.8))
+                    .background(LinearGradient(colors: [.primaryColor, .secondaryColor], startPoint: .leading, endPoint: .trailing))
                         .cornerRadius(12)
                         .foregroundColor(.white)
                     Button("Logout") {
@@ -54,7 +54,7 @@ struct ProfileView: View {
                         dismiss()
                     }
                     .padding()
-                    .background(Color.red)
+                    .background(LinearGradient(colors: [.primaryColor, .secondaryColor], startPoint: .leading, endPoint: .trailing))
                     .cornerRadius(12)
                     .foregroundColor(.white)
                 }

--- a/product-base/ios-app/RNGApp/Views/SignupView.swift
+++ b/product-base/ios-app/RNGApp/Views/SignupView.swift
@@ -8,7 +8,7 @@ struct SignupView: View {
 
     var body: some View {
         ZStack {
-            LinearGradient(colors: [.purple, .pink, .red], startPoint: .topLeading, endPoint: .bottomTrailing)
+            LinearGradient(colors: [.primaryColor, .secondaryColor], startPoint: .topLeading, endPoint: .bottomTrailing)
                 .ignoresSafeArea()
             ScrollView {
                 VStack(spacing: 12) {
@@ -33,7 +33,7 @@ struct SignupView: View {
                     }
                     .frame(maxWidth: .infinity)
                     .padding()
-                    .background(Color.purple)
+                    .background(LinearGradient(colors: [.primaryColor, .secondaryColor], startPoint: .leading, endPoint: .trailing))
                     .foregroundColor(.white)
                     .cornerRadius(16)
                 }

--- a/product-base/web-app/app/auth/login/page.tsx
+++ b/product-base/web-app/app/auth/login/page.tsx
@@ -39,7 +39,7 @@ export default function LoginPage() {
   // Show loading while checking authentication
   if (isCheckingAuth) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-purple-400 via-pink-500 to-red-500 flex items-center justify-center">
+      <div className="min-h-screen bg-gradient-to-br from-primary to-secondary flex items-center justify-center">
         <div className="text-center">
           <div className="animate-spin rounded-full h-16 w-16 border-b-4 border-white mb-4"></div>
           <p className="text-white text-lg">Checking authentication...</p>
@@ -49,7 +49,7 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-purple-400 via-pink-500 to-red-500 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gradient-to-br from-primary to-secondary flex items-center justify-center p-4">
       <div className="bg-white/90 backdrop-blur-sm rounded-3xl shadow-2xl p-8 w-full max-w-md">
         <div className="text-center mb-8">
           <h1 className="font-['Pacifico'] text-4xl text-gray-800 mb-2">RNG</h1>
@@ -82,7 +82,7 @@ export default function LoginPage() {
           <button
             type="submit"
             disabled={isLoading}
-            className="w-full bg-gradient-to-r from-purple-500 to-pink-500 text-white py-3 rounded-2xl font-semibold hover:from-purple-600 hover:to-pink-600 transition-all duration-300 transform hover:scale-105 !rounded-button disabled:opacity-50"
+            className="w-full bg-gradient-to-r from-primary to-secondary text-white py-3 rounded-2xl font-semibold hover:from-primary hover:to-secondary transition-all duration-300 transform hover:scale-105 !rounded-button disabled:opacity-50"
           >
             {isLoading ? (
               <div className="flex items-center justify-center">
@@ -98,7 +98,7 @@ export default function LoginPage() {
         <div className="text-center mt-6">
           <p className="text-gray-600">
             Don't have an account?{' '}
-            <Link href="/auth/signup" className="text-purple-600 hover:text-purple-800 font-semibold">
+            <Link href="/auth/signup" className="text-primary hover:text-secondary font-semibold">
               Sign up
             </Link>
           </p>

--- a/product-base/web-app/app/auth/signup/page.tsx
+++ b/product-base/web-app/app/auth/signup/page.tsx
@@ -41,7 +41,7 @@ export default function SignupPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-400 via-purple-500 to-pink-500 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gradient-to-br from-primary to-secondary flex items-center justify-center p-4">
       <div className="bg-white/90 backdrop-blur-sm rounded-3xl shadow-2xl p-8 w-full max-w-md max-h-[90vh] overflow-y-auto">
         <div className="text-center mb-6">
           <h1 className="font-[\'Pacifico\'] text-4xl text-gray-800 mb-2">RNG</h1>
@@ -144,7 +144,7 @@ export default function SignupPage() {
           <button
             type="submit"
             disabled={isLoading}
-            className="w-full bg-gradient-to-r from-blue-500 to-purple-500 text-white py-3 rounded-2xl font-semibold hover:from-blue-600 hover:to-purple-600 transition-all duration-300 transform hover:scale-105 !rounded-button disabled:opacity-50"
+            className="w-full bg-gradient-to-r from-primary to-secondary text-white py-3 rounded-2xl font-semibold hover:from-primary hover:to-secondary transition-all duration-300 transform hover:scale-105 !rounded-button disabled:opacity-50"
           >
             {isLoading ? (
               <div className="flex items-center justify-center">
@@ -160,7 +160,7 @@ export default function SignupPage() {
         <div className="text-center mt-6">
           <p className="text-gray-600">
             Already have an account?{' '}
-            <Link href="/auth/login" className="text-purple-600 hover:text-purple-800 font-semibold">
+            <Link href="/auth/login" className="text-primary hover:text-secondary font-semibold">
               Login
             </Link>
           </p>

--- a/product-base/web-app/app/dashboard/page.tsx
+++ b/product-base/web-app/app/dashboard/page.tsx
@@ -39,7 +39,7 @@ export default function Dashboard() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-indigo-400 via-purple-500 to-pink-500 relative overflow-hidden">
+    <div className="min-h-screen bg-gradient-to-br from-primary to-secondary relative overflow-hidden">
       {/* Animated background elements */}
       <div className="absolute inset-0 overflow-hidden">
         <div className="absolute -top-10 -left-10 w-40 h-40 bg-white/10 rounded-full animate-pulse"></div>
@@ -92,7 +92,7 @@ export default function Dashboard() {
         <button
           onClick={generateNumber}
           disabled={isGenerating}
-          className="w-20 h-20 bg-gradient-to-r from-yellow-400 to-orange-500 rounded-full shadow-2xl hover:shadow-yellow-500/25 transform hover:scale-110 transition-all duration-300 disabled:opacity-70 disabled:cursor-not-allowed !rounded-button flex items-center justify-center"
+          className="w-20 h-20 bg-gradient-to-r from-primary to-secondary rounded-full shadow-2xl hover:shadow-primary/25 transform hover:scale-110 transition-all duration-300 disabled:opacity-70 disabled:cursor-not-allowed !rounded-button flex items-center justify-center"
         >
           <div className="text-center">
             <i className="ri-dice-line text-white text-2xl mb-1"></i>

--- a/product-base/web-app/app/history/page.tsx
+++ b/product-base/web-app/app/history/page.tsx
@@ -56,7 +56,7 @@ export default function HistoryPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-400 via-purple-500 to-pink-500">
+    <div className="min-h-screen bg-gradient-to-br from-primary to-secondary">
       <div className="bg-white/10 backdrop-blur-sm">
         <div className="flex items-center justify-between p-6">
           <Link href="/profile" className="text-white hover:text-white/80 transition-colors">

--- a/product-base/web-app/app/page.tsx
+++ b/product-base/web-app/app/page.tsx
@@ -21,7 +21,7 @@ export default function Home() {
   // Show loading while checking authentication
   if (isCheckingAuth) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-purple-400 via-pink-500 to-red-500 flex items-center justify-center">
+      <div className="min-h-screen bg-gradient-to-br from-primary to-secondary flex items-center justify-center">
         <div className="text-center">
           <div className="animate-spin rounded-full h-16 w-16 border-b-4 border-white mb-4"></div>
           <p className="text-white text-lg">Loading your account...</p>
@@ -31,7 +31,7 @@ export default function Home() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-purple-400 via-pink-500 to-red-500 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gradient-to-br from-primary to-secondary flex items-center justify-center p-4">
       <div className="text-center">
         <div className="mb-12">
           <h1 className="font-['Pacifico'] text-8xl text-white mb-4 drop-shadow-2xl">RNG</h1>
@@ -48,7 +48,7 @@ export default function Home() {
           </Link>
 
           <Link href="/auth/signup">
-            <button className="w-80 bg-gradient-to-r from-yellow-400 to-orange-500 text-white py-4 rounded-2xl font-semibold hover:from-yellow-500 hover:to-orange-600 transition-all duration-300 transform hover:scale-105 !rounded-button shadow-lg">
+            <button className="w-80 bg-gradient-to-r from-primary to-secondary text-white py-4 rounded-2xl font-semibold hover:from-primary hover:to-secondary transition-all duration-300 transform hover:scale-105 !rounded-button shadow-lg">
               <i className="ri-user-add-line mr-2"></i>
               Sign Up
             </button>

--- a/product-base/web-app/app/profile/page.tsx
+++ b/product-base/web-app/app/profile/page.tsx
@@ -76,7 +76,7 @@ export default function ProfilePage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-400 via-purple-500 to-pink-500">
+    <div className="min-h-screen bg-gradient-to-br from-primary to-secondary">
       {/* Header */}
       <div className="bg-white/10 backdrop-blur-sm">
         <div className="flex items-center justify-between p-6">
@@ -92,7 +92,7 @@ export default function ProfilePage() {
         {/* Profile card */}
         <div className="bg-white/90 backdrop-blur-sm rounded-3xl p-6 shadow-xl">
           <div className="text-center mb-6">
-            <div className="w-24 h-24 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full mx-auto mb-4 flex items-center justify-center">
+            <div className="w-24 h-24 bg-gradient-to-r from-primary to-secondary rounded-full mx-auto mb-4 flex items-center justify-center">
               <i className="ri-user-line text-white text-4xl"></i>
             </div>
             <h2 className="text-2xl font-bold text-gray-800">{user.full_name}</h2>
@@ -101,11 +101,11 @@ export default function ProfilePage() {
 
           {/* Stats */}
           <div className="grid grid-cols-2 gap-4 mb-6">
-            <div className="bg-gradient-to-r from-blue-500 to-purple-500 rounded-2xl p-4 text-center text-white">
+            <div className="bg-gradient-to-r from-primary to-secondary rounded-2xl p-4 text-center text-white">
               <div className="text-2xl font-bold">{stats.totalNumbersGenerated}</div>
               <div className="text-sm opacity-90">Numbers Generated</div>
             </div>
-            <div className="bg-gradient-to-r from-green-500 to-emerald-500 rounded-2xl p-4 text-center text-white">
+            <div className="bg-gradient-to-r from-primary to-secondary rounded-2xl p-4 text-center text-white">
               <div className="text-lg font-bold">{stats.bestNumber.toLocaleString()}</div>
               <div className="text-sm opacity-90">Best Number</div>
             </div>
@@ -180,7 +180,7 @@ export default function ProfilePage() {
               <button
                 type="submit"
                 disabled={isSaving}
-                className="w-full bg-gradient-to-r from-purple-500 to-pink-500 text-white py-3 rounded-2xl font-semibold hover:from-purple-600 hover:to-pink-600 transition-all duration-300 !rounded-button disabled:opacity-50"
+                className="w-full bg-gradient-to-r from-primary to-secondary text-white py-3 rounded-2xl font-semibold hover:from-primary hover:to-secondary transition-all duration-300 !rounded-button disabled:opacity-50"
               >
                 {isSaving ? 'Saving...' : 'Save'}
               </button>
@@ -192,7 +192,7 @@ export default function ProfilePage() {
         <div className="space-y-3">
           <button
             onClick={() => setIsEditing(!isEditing)}
-            className="w-full bg-gradient-to-r from-purple-500 to-pink-500 text-white py-4 rounded-2xl font-semibold hover:from-purple-600 hover:to-pink-600 transition-all duration-300 !rounded-button"
+            className="w-full bg-gradient-to-r from-primary to-secondary text-white py-4 rounded-2xl font-semibold hover:from-primary hover:to-secondary transition-all duration-300 !rounded-button"
           >
             <i className="ri-settings-line mr-2"></i>
             {isEditing ? 'Cancel' : 'Update Profile Settings'}
@@ -200,7 +200,7 @@ export default function ProfilePage() {
 
           <Link
             href="/history"
-            className="w-full bg-gradient-to-r from-blue-500 to-indigo-500 text-white py-4 rounded-2xl font-semibold hover:from-blue-600 hover:to-indigo-600 transition-all duration-300 !rounded-button flex items-center justify-center"
+            className="w-full bg-gradient-to-r from-primary to-secondary text-white py-4 rounded-2xl font-semibold hover:from-primary hover:to-secondary transition-all duration-300 !rounded-button flex items-center justify-center"
           >
             <i className="ri-history-line mr-2"></i>
             Number History
@@ -208,7 +208,7 @@ export default function ProfilePage() {
 
           <button
             onClick={handleLogout}
-            className="w-full bg-gradient-to-r from-red-500 to-pink-500 text-white py-4 rounded-2xl font-semibold hover:from-red-600 hover:to-pink-600 transition-all duration-300 !rounded-button"
+            className="w-full bg-gradient-to-r from-primary to-secondary text-white py-4 rounded-2xl font-semibold hover:from-primary hover:to-secondary transition-all duration-300 !rounded-button"
           >
             <i className="ri-logout-box-line mr-2"></i>
             Logout

--- a/product-base/web-app/components/LoadingAnimation.tsx
+++ b/product-base/web-app/components/LoadingAnimation.tsx
@@ -12,26 +12,26 @@ export default function LoadingAnimation({ isVisible }: LoadingAnimationProps) {
       <div className="bg-white/90 backdrop-blur-sm rounded-3xl p-8 flex flex-col items-center">
         <div className="relative">
           {/* Outer rotating ring */}
-          <div className="w-24 h-24 rounded-full border-4 border-purple-200 border-t-purple-600 animate-spin"></div>
+          <div className="w-24 h-24 rounded-full border-4 border-secondary/20 border-t-primary animate-spin"></div>
           
           {/* Inner pulsing circle */}
-          <div className="absolute inset-4 w-16 h-16 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full animate-pulse flex items-center justify-center">
+          <div className="absolute inset-4 w-16 h-16 bg-gradient-to-r from-primary to-secondary rounded-full animate-pulse flex items-center justify-center">
             <div className="w-8 h-8 bg-white rounded-full animate-bounce"></div>
           </div>
           
           {/* Sparkle effects */}
-          <div className="absolute -top-2 -right-2 w-4 h-4 bg-yellow-400 rounded-full animate-ping"></div>
-          <div className="absolute -bottom-2 -left-2 w-3 h-3 bg-blue-400 rounded-full animate-ping" style={{ animationDelay: '0.5s' }}></div>
-          <div className="absolute top-1/2 -right-4 w-2 h-2 bg-green-400 rounded-full animate-ping" style={{ animationDelay: '1s' }}></div>
+          <div className="absolute -top-2 -right-2 w-4 h-4 bg-primary rounded-full animate-ping"></div>
+          <div className="absolute -bottom-2 -left-2 w-3 h-3 bg-secondary rounded-full animate-ping" style={{ animationDelay: '0.5s' }}></div>
+          <div className="absolute top-1/2 -right-4 w-2 h-2 bg-primary rounded-full animate-ping" style={{ animationDelay: '1s' }}></div>
         </div>
         
         <p className="text-gray-700 font-semibold mt-6 animate-pulse">Generating your lucky number...</p>
         
         {/* Animated dots */}
         <div className="flex space-x-1 mt-2">
-          <div className="w-2 h-2 bg-purple-500 rounded-full animate-bounce"></div>
-          <div className="w-2 h-2 bg-purple-500 rounded-full animate-bounce" style={{ animationDelay: '0.1s' }}></div>
-          <div className="w-2 h-2 bg-purple-500 rounded-full animate-bounce" style={{ animationDelay: '0.2s' }}></div>
+          <div className="w-2 h-2 bg-primary rounded-full animate-bounce"></div>
+          <div className="w-2 h-2 bg-primary rounded-full animate-bounce" style={{ animationDelay: '0.1s' }}></div>
+          <div className="w-2 h-2 bg-primary rounded-full animate-bounce" style={{ animationDelay: '0.2s' }}></div>
         </div>
       </div>
     </div>

--- a/product-base/web-app/tailwind.config.js
+++ b/product-base/web-app/tailwind.config.js
@@ -2,7 +2,12 @@
 module.exports = {
   content: ["./{app,components,libs,pages,hooks}/**/*.{html,js,ts,jsx,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: '#ec4899',
+        secondary: '#818cf8',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- add primary (#ec4899) and secondary (#818cf8) theme colors
- use primary-secondary gradients on main screens for web, iOS and Android

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint must be installed)*
- `./gradlew test` *(fails: SDK location not found)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6893744a45b0832e8e4a5416cc87dcd7