### PR TITLE
Document baseline apps and server dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # lucra-demo-product
 
-This demo displays how a useful product can integrate the Lucra SDK from the perspective of Web, Mobile and Backend infrastructure
+This repository contains the baseline RNG product experience before any Lucra SDK
+integration. All apps and services in this project communicate with a standalone
+server hosted at <http://playrng.us-east-1.elasticbeanstalk.com>.
 
 ## product-base
 
-This is the RNG product which functions as normal before introducing the Lucra SDK functionality
+The `product-base` directory is the reference implementation used prior to
+adding Lucra features. It includes:
 
-`/web-app` is the functioning web app interacting with `/API`
-`/api` is the functioning API
+- `web-app` – functioning web app interacting with the API
+- `api` – backend API serving the apps
+- `android-app` – Android client pointing to the remote server
+- `ios-app` – iOS client pointing to the remote server
 
-TODO
-
-## product-lucra-gyp-autosettlement
-
-TODO
-
-## product-lucra-tournaments
+This setup allows developers to explore the core product experience without any
+Lucra-specific components.

--- a/product-base/android-app/README.md
+++ b/product-base/android-app/README.md
@@ -1,0 +1,17 @@
+# Android App
+
+This module contains the Android client for the baseline RNG product. By
+default it communicates with the remote server at
+<http://playrng.us-east-1.elasticbeanstalk.com>.
+
+## Running the App
+
+1. Open the `product-base/android-app` directory in **Android Studio**
+   (`File` → `Open`).
+2. Let Gradle synchronize and download any required dependencies.
+3. Select a device or emulator.
+4. Press **Run** to build and launch the application.
+
+The server URL can be modified in code if needed, but out of the box it points
+to the remote server above.
+

--- a/product-base/ios-app/README.md
+++ b/product-base/ios-app/README.md
@@ -1,0 +1,15 @@
+# iOS App
+
+This directory contains the iOS client for the baseline RNG product. By
+default the application sends requests to the remote server at
+<http://playrng.us-east-1.elasticbeanstalk.com>.
+
+## Running the App
+
+1. Open `RNGApp.xcodeproj` in **Xcode**.
+2. Choose a simulator or a connected device.
+3. Press **Run** (or use `Cmd + R`) to build and launch the app.
+
+The server URL can be modified in code if necessary, but the default
+configuration targets the remote server above.
+


### PR DESCRIPTION
## Summary
- clarify root README with baseline product context and remote server
- add Android app README with Android Studio run instructions
- add iOS app README with Xcode run instructions

## Testing
- `./gradlew test --dry-run` (fails: SDK location not found)
- `xcodebuild -list` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_6893873a4020832eba23168b731400bc