### PR TITLE
Fetch recent numbers from API and log network activity

### DIFF
--- a/product-base/android-app/app/build.gradle.kts
+++ b/product-base/android-app/app/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation("androidx.navigation:navigation-compose:2.9.3")
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
+    implementation("com.squareup.okhttp3:logging-interceptor:4.10.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
     implementation("androidx.appcompat:appcompat:1.7.1")
 

--- a/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/DashboardScreen.kt
+++ b/product-base/android-app/app/src/main/java/com/lucra/android/ui/screens/DashboardScreen.kt
@@ -63,6 +63,7 @@ fun DashboardScreen(navController: NavController) {
             runCatching { ApiClient.service.getStats(it.id) }.onSuccess { stats ->
                 totalNumbers = stats.totalNumbersGenerated
             }
+            UserManager.refreshNumbers(it.id)
         }
     }
 
@@ -74,9 +75,9 @@ fun DashboardScreen(navController: NavController) {
             scale.animateTo(1.2f, animationSpec = tween(durationMillis = 200))
             scale.animateTo(1f, animationSpec = tween(durationMillis = 200))
             user?.let {
-                UserManager.addNumber(it.id, target)
                 totalNumbers += 1
                 lastAdded = target
+                UserManager.refreshNumbers(it.id)
             }
             isGenerating = false
         }


### PR DESCRIPTION
## Summary
- Retrieve recent numbers from the backend instead of local storage to keep dashboard in sync
- Log every network request/response and clear local session when the server reports a missing user
- Add OkHttp logging interceptor dependency

## Testing
- `npm test`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893860d9310832e87b234437b04e203