### PR TITLE
docs: clarify S3 credential setup for local testing

### DIFF
--- a/product-base/api/README.md
+++ b/product-base/api/README.md
@@ -25,10 +25,15 @@ cp .env.example .env
 The following variables are used to optionally sync the SQLite database with an
 S3 bucket:
 
-- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` – credentials with access to the bucket **(TODO: configure in EB as well)**
 - `AWS_REGION` – AWS region of the bucket
 - `S3_BUCKET` – bucket name where the SQLite file is stored
 - `S3_DB_KEY` – object key inside the bucket (defaults to `database.sqlite`)
+
+To test S3 locally, obtain temporary AWS credentials (access key ID, secret, and
+session token) from your [access landing page](https://lucra-sports.awsapps.com/start/#/?tab=accounts).
+These credentials require read and write access to the `dev` account and should
+be exported as `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and
+`AWS_SESSION_TOKEN` before starting the server.
 
 If these variables are missing or the S3 object does not exist, the API falls
 back to creating a local SQLite database. Remember to set equivalent environment

--- a/product-base/api/server.js
+++ b/product-base/api/server.js
@@ -15,9 +15,9 @@ require("dotenv").config();
 const isTestEnv = process.env.NODE_ENV === "test";
 const dbFile = isTestEnv ? "database.test.sqlite" : "database.sqlite";
 
-// AWS S3 configuration. Credentials are expected via environment variables
-// (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION). All are TODOs and
-// must be configured in the EB environment and in the local `.env` file.
+// AWS S3 configuration. Credentials are expected via environment variables.
+// To test with S3 locally, obtain AWS key, secret, and session token from the
+// access landing page (requires read/write access to dev).
 const s3Bucket = process.env.S3_BUCKET; // TODO: set S3 bucket name
 const s3Key = process.env.S3_DB_KEY || dbFile; // TODO: optional custom key
 const s3Region = process.env.AWS_REGION; // TODO: AWS region


### PR DESCRIPTION
## Summary
- clarify API README instructions on obtaining AWS credentials from the access landing page for local S3 testing
- remove AWS access key/secret references in comments and docs

## Testing
- `cd product-base/api && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689547d71338832e8517d46ed284e2d1