### PR TITLE
docs: add overview README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Lucra Demo Product
+
+This repository showcases three variations of the RNG product and how Lucra features layer onto the base experience.
+
+## Folder overview
+
+| Folder | Description | Server URL |
+| --- | --- | --- |
+| `product-base` | Baseline RNG product with no Lucra integration. Use this to explore the core experience. | http://playrng.us-east-1.elasticbeanstalk.com |
+| `product-lucra-gyp` | Base product plus the Lucra SDK "GYP" (Games You Play) integration. Demonstrates how GYP blends into the existing product. | http://playrng-lucra-gyp.us-east-1.elasticbeanstalk.com |
+| `product-lucra-tournaments` | Base product with the Lucra Tournaments SDK added, illustrating tournament play. | http://playrng-lucra-tournaments.us-east-1.elasticbeanstalk.com |
+
+Each directory includes a `web-app`, `api`, `android-app`, and `ios-app` that point to their respective servers. The variations let you see how additional Lucra functionality mixes naturally into the product.


### PR DESCRIPTION
## Summary
- document the differences between the base, Lucra GYP, and Lucra tournament product examples

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a172b265c832ebeb52b9e9a267fed