### PR TITLE
chore: add self-signed cert for testing against AWS Amplify

### DIFF
--- a/product-lucra-gyp/api/.ebextensions/ssl.config
+++ b/product-lucra-gyp/api/.ebextensions/ssl.config
@@ -1,0 +1,116 @@
+# WARNING: This file contains a self-signed SSL certificate and private key.
+# This is for local development or sandbox testing ONLY. 
+
+files:
+  "/etc/pki/tls/certs/server.crt":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      -----BEGIN CERTIFICATE-----
+      MIIF4jCCA8oCCQDcQL1LU2cu8TANBgkqhkiG9w0BAQsFADCBsjELMAkGA1UEBhMC
+      VVMxETAPBgNVBAgMCE5ldyBZb3JrMREwDwYDVQQHDAhOZXcgWW9yazEUMBIGA1UE
+      CgwLTHVjcmEsIEluYy4xFDASBgNVBAsMC0VuZ2luZWVyaW5nMSswKQYDVQQDDCJt
+      YWluLmQxZ291amZyczVtYW1sLmFtcGxpZnlhcHAuY29tMSQwIgYJKoZIhvcNAQkB
+      FhVrZXZpbkBsdWNyYXNwb3J0cy5jb20wHhcNMjUwODE1MjAxOTIwWhcNMjYwODE1
+      MjAxOTIwWjCBsjELMAkGA1UEBhMCVVMxETAPBgNVBAgMCE5ldyBZb3JrMREwDwYD
+      VQQHDAhOZXcgWW9yazEUMBIGA1UECgwLTHVjcmEsIEluYy4xFDASBgNVBAsMC0Vu
+      Z2luZWVyaW5nMSswKQYDVQQDDCJtYWluLmQxZ291amZyczVtYW1sLmFtcGxpZnlh
+      cHAuY29tMSQwIgYJKoZIhvcNAQkBFhVrZXZpbkBsdWNyYXNwb3J0cy5jb20wggIi
+      MA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDLc+ZAd6BA02PyXCff0VrG2hqX
+      MpV/aMCquhwHTQuoRpesaCr4s89T414libz+DAeZSc6cL40YewYML1emCekEfDgM
+      1p9tf19LJX/pYrhIlG11lUSY/7/WKfsycJWqwDD75P+3gNwsZkpOhxlYUtPtVZ7w
+      ZTjZFwds9vD6Lj8pzeMiVpcT4oYrXrX0kHrrBw6eb1y7XWUghii2bNvecGisIRXU
+      UIfWYzBy1KnEv9Ss7pXyspJX+6oI9u6LtdS8o/7xvgs5QMjCy690flif7A5KC64d
+      XrqP32uBto2rgMkMEuAB0MGLPqEsTvnJd7NIbu1kML9Jvi+Z4JFySMAZ8IxBNc5j
+      VvAfshdjdGJSf6v1Q46XBANFpnsc3WfZySPZSuz4evesubrcF80LeQ5xTq2d19mL
+      vNLXYqo7xZ2wdqzLCP1zFg6GbI8oErQ5sxPcb6+4tjeJZwIVp9RZ2MtiWvqDQ5vI
+      Q6btbhNpYBS2BSMLbjgkOiMpoOelRyTrHxXRKj7EOj6rT3q9EMTsPYUrerw9P7jq
+      bFz6s08/4KQFpdFmZhwlFWE60GfAjHL8nyEANfjQ2Q/ydVoNy2rAr2rRE6WFOMtU
+      ydYAyPIGvqZpFLimIdqR2b1MmA4+ScKLY3KSa+53kp+N7NKD/0ZvC4wfrUFQviBr
+      jWyjcwZcnnhV4s0iyQIDAQABMA0GCSqGSIb3DQEBCwUAA4ICAQBSplKE9mWF/sao
+      8gM6iglcFq/X9GuE/dq/6mufQHhqr6R738BR39dgeMTSsRUUQErqb3WHNpcxv3TF
+      DbIzpsCrFiwHHYGm9PBQOgOhBKePA/e92v26Qjn34tkg6rC6Ho1EPfnD35jiCNcO
+      EWKwRwzf3NJLGi462Qc+l7dpNaph5a6jzFTun9XvETwrpQ4VM992k5pyYTKxJ9mC
+      IgVdbxko1+bjCbXApQo1QjwjZSv2K+ojS4KUCuCp0H3pVD/KJwqaCp2GA856dhoH
+      RcwzsbSvykWWfTunFzuGxJNXnQfNcGxhWSPBuv8ADNSbjDsn1nhcmDCJGgrxg+Ao
+      G7D7Z0VR2T4MHdFSciE3ugqhEHBvu/CyMHKK4ASIvWnSDIzj2R84hktdD9O6nJ97
+      pVzahfR2nBb/MGhlJdICKpA+JLkFJCPYTmlFSGEBlQbi4FE0VFqTZCDufNtzidg5
+      KE6Wlg1Erk+CX+LvOsHpe33Xly+X/tKT56t79XPkO5zwrbIn9gUJFxucKE8KOkfN
+      CkonKDYfm/+2jCslydKWJTfFjG/gLhLLQtXcq26xyhR7Rv7h+BL3FUtmn9+wVojy
+      aCxK5KWicsMOHY4VfdFvSv+Ft65xhvRZVkmJdyGk8SWWZLT5hPgC4kzShqK+0dN8
+      GA/J741xT6Dui/uJiZIU8UEwZIFJEQ==
+      -----END CERTIFICATE-----
+
+  "/etc/pki/tls/private/server.key":
+    mode: "000600"
+    owner: root
+    group: root
+    content: |
+      -----BEGIN PRIVATE KEY-----
+      MIIJQwIBADANBgkqhkiG9w0BAQEFAASCCS0wggkpAgEAAoICAQDLc+ZAd6BA02Py
+      XCff0VrG2hqXMpV/aMCquhwHTQuoRpesaCr4s89T414libz+DAeZSc6cL40YewYM
+      L1emCekEfDgM1p9tf19LJX/pYrhIlG11lUSY/7/WKfsycJWqwDD75P+3gNwsZkpO
+      hxlYUtPtVZ7wZTjZFwds9vD6Lj8pzeMiVpcT4oYrXrX0kHrrBw6eb1y7XWUghii2
+      bNvecGisIRXUUIfWYzBy1KnEv9Ss7pXyspJX+6oI9u6LtdS8o/7xvgs5QMjCy690
+      flif7A5KC64dXrqP32uBto2rgMkMEuAB0MGLPqEsTvnJd7NIbu1kML9Jvi+Z4JFy
+      SMAZ8IxBNc5jVvAfshdjdGJSf6v1Q46XBANFpnsc3WfZySPZSuz4evesubrcF80L
+      eQ5xTq2d19mLvNLXYqo7xZ2wdqzLCP1zFg6GbI8oErQ5sxPcb6+4tjeJZwIVp9RZ
+      2MtiWvqDQ5vIQ6btbhNpYBS2BSMLbjgkOiMpoOelRyTrHxXRKj7EOj6rT3q9EMTs
+      PYUrerw9P7jqbFz6s08/4KQFpdFmZhwlFWE60GfAjHL8nyEANfjQ2Q/ydVoNy2rA
+      r2rRE6WFOMtUydYAyPIGvqZpFLimIdqR2b1MmA4+ScKLY3KSa+53kp+N7NKD/0Zv
+      C4wfrUFQviBrjWyjcwZcnnhV4s0iyQIDAQABAoICAQC/6RyJNQ4h+ASwKYOnWPiy
+      2Cr68kkYfLw4jwM/U8qqOaR6iWv3Ws03ySIWcJ2oWbqVOoy8wRHrxKgIuGOKCJEX
+      nQDWA2ExTVObM807XdaNCA1UO7AQTjYrk0AS7SYQgefyw6j+9Hs7GmX/OuqKaN7l
+      Yb1h72k3RcTIYQsgQp1sFnyo+Frb8/IxWM5z2hFIP0jn5A3p4wgwLLycj4S6hvgF
+      XdQUiL4JWVjrCHT3VSgM06T34L+wZICYoiyT9rmsE1m5uFUn9VcqgC2JymBYwbcc
+      23Wq2J9MdSgYnBV4cCu0yt0oeT0H1tT7UafHBbVEnvYoat8VdWO7V5x62+rwzPnO
+      HLR45nWy5qx6JVKpAga9xkjDvzNWK61hqCyqn3okgjz+w0LEmrvKJ/cjFa+lWs1z
+      4XfoFfd+4sl68Ce/n5zxBGY/PrqubQVzCCBh4f7HJCbtz5ka0Rz1rMlkvNKKZTET
+      nHlgJGNFIh8m/N0bqiGsWJf46GYtWjDtBe2SmDtndScOdsv6T2+Ww/5SSS+M8QEQ
+      JvArnF3MekI2jja/YMDH14hK+7Gisqa5jt5wry1IceIHB3uj8qi3aiEvJYahrpKp
+      aaV/8MWWEEsWpUJuo2fNGjTyhD6IkZcmrVAsBkGC3Ru0FWikceCscxcQ/36sPSOm
+      QNPloTxpzXIJkph+GYO6sQKCAQEA+teiB0NhtfBTSoaCf/3MW1n2+a3b8IPe+8mB
+      oWfDmptj5jfNbAuzfL/Xte4GjyQAI86BCag0pHlIwmAfyS9ruImgJ8Qgob3r7e6h
+      NiVIdlzB5RWxMWKnVE/jtgtwIQgw/3d0sTnRNoZKrMdXyNJHe3FGy5bOYVyXoabs
+      ZJljPtBNMF88UpkhymUOzNJhJ4FbJJ5NuiuypDJ+KBJm2eZews5wO2HCOL9MrI1i
+      aTu30Oyqxwel1Lsrqf6xRyJF+1k6MyuklD3Udaj6mfIFrll4EI/oXZGUB5I4DRf7
+      HWfu+rhMS05VDrEeJ8xIH1kohdtRpjOuMEJVzbCSG/yeADKpPQKCAQEAz6LSAz1X
+      H0JrjgRA2YmYMgkPeEWUc4X5/U4C9qWWCG994NxyUti4KJ5l4xfS8OvWInq86/4k
+      5KCpSz5T+cNBWhI4HGb9zkeiLsEfinVQIEZyF3+dSeccSqrlrhsMyvIsT34mIvZK
+      fx3vOww7/u4kg5lLQti+nfa3qjomHICUfvxe0mefRpXbNy4qjuiXXLehNdmhqLdG
+      wivsGoR8gYjbog+GfvLcFwdlMA58Qmbmxn6PWzlWMkHKZO+9CZoIDnpeAwpDBO8e
+      7ebaeSu4Ic4wW4iRnnR15V2/XSh7M6k58dDgXX+NubRk0/8ZJq5uESYNQQ3DZJHD
+      0lVNZUA2LlqAfQKCAQAZ5ZU2xsAZtnwC36wtZphoffs/f7GLPTISMJWPglTxa0V/
+      CRfOJc8b+/pbL/3BXWgeSj2ML69vo43dc2sUrC6k2KCOOnNb/22SHObL3kGC5sSl
+      z/2BKbw4uh66NqgW4O+eEEkd2ug8htTCzbnEY+E5X1J9xk38Q0DsUX1qTWOvonW1
+      nr9tj52rdY93meip2XL9btJ7e/NvfD8GCBBSQrRZzFJN7yPMFAPodJhKYP3zNdvT
+      vHhkZAZ4AHFw9Jrg/i9CBSlynIeIti9ZIWFwxI/etdy5fEQaHABpaaZlPMuxWsGV
+      rLqfT63bUf3ILr4+Q4xEamV7Wf3dxHLxLL1rK8/JAoIBAD1gxy4X+uINs1eW4Eiu
+      COR5ky4de2Wu7Bg58FxS1IgH1TEcWVsuHzo6oKnByCRZwsIMgD5OsT84UvMgKJjD
+      ZFUo35ddxpcsy7+AbT9zsEzqJh3WJnvLKqzT2fNeoah4cCrLgqCBJ8Jt6eMNmcqh
+      QP/516qaAbcWUHKsn8l7JOpo1erioM2vzM6CAiiejufkjG4ruEL0cqFBdJjeIyPz
+      feFpL3vldLQGBp5vGcJTQtLYZK41w8o1covl5n6pHsqQ16uUY/1YZk8zF9AL4XF0
+      zwyv0UQC7zrvPHtgVRMPakaWVUyuQQntToTwetHZbEX7dp2NYP4grL9HYgqVMa8A
+      J80CggEBAISFHUPceAoy1TLOZyPxXMDZ3DarjhdB8p9N1ToqzzefC1DVTc/eQux5
+      epQovE1wa5RuAeIs/RvGJpleZf29HjVc++Izl1mj6D67GJH6WPTp1oWiEAIuWwo7
+      aHJXigubmPlJWXWzXH9TwrY3XAkQ9JoehVRVM/XmHI4uilsE0ecPt0QP0cHk+IcH
+      Pj/n7FxcgDV7h5TVMIFvMwwiigCbJWcSoTCIZYIImENWJi6mxtwGM/ivW1N3Y8B5
+      vdQzpxGEaDAEQv/sMxFt3jKoSgsko8NoHtKU3C6VFdwfBEVovK/Ewv2Ztd7yxSzo
+      rYXrY9dxXmDcv8vGG/Fyf0GvSLa+Uc8=
+      -----END PRIVATE KEY-----
+
+commands:
+  configure_ssl:
+    command: |
+      CONF_FILE="/etc/nginx/conf.d/elasticbeanstalk/00_application.conf"
+      if grep -q "listen 80;" "$CONF_FILE"; then
+        sed -i '/listen 80;/a \
+        listen 443 ssl; \
+        ssl_certificate /etc/pki/tls/certs/server.crt; \
+        ssl_certificate_key /etc/pki/tls/private/server.key;' "$CONF_FILE"
+      fi
+
+container_commands:
+  01_reload_nginx:
+    command: "service nginx reload"


### PR DESCRIPTION
## Jira
N/A

## Description
Adds a self-signed certificate for Elastic Beanstalk (since we're using single-instance there, we can't use AWS Certificate Manager and attach to the load balancer via Beanstalk console). This will (hopefully) allow us to hit the Beanstalk instance (because AWS Amplify requires HTTPS and it can't be disabled). Our AWS Amplify App is [here](https://main.d1goujfrs5maml.amplifyapp.com/).


## Testing
N/A


## Screenshots / Recordings
N/A
