### PR TITLE
Use base domain for deep link response

### DIFF
--- a/product-lucra-gyp/web-app/lib/lucraClient.ts
+++ b/product-lucra-gyp/web-app/lib/lucraClient.ts
@@ -98,9 +98,7 @@ function handleDeepLinkRequest({ url }: { url: string }) {
   // Create a share URL using the current domain
   const baseDomain =
     typeof window !== "undefined" ? window.location.origin : "";
-  const shareUrl = `${baseDomain}?redirect=${encodeURIComponent(
-    storedRedirectUrl
-  )}`;
+  const shareUrl = `${baseDomain}?redirect=${storedRedirectUrl}`;
   console.log("!!!: RNG: Custom deep link URL: ", shareUrl);
 
   lucraClient?.sendMessage.deepLinkResponse({

--- a/product-lucra-gyp/web-app/lib/lucraClient.ts
+++ b/product-lucra-gyp/web-app/lib/lucraClient.ts
@@ -95,8 +95,12 @@ function handleDeepLinkRequest({ url }: { url: string }) {
   // Store the original Lucra URL as redirect URL
   storedRedirectUrl = url;
 
-  // Create a generic localhost share URL
-  const shareUrl = `http://localhost:3000?redirect=${storedRedirectUrl}`;
+  // Create a share URL using the current domain
+  const baseDomain =
+    typeof window !== "undefined" ? window.location.origin : "";
+  const shareUrl = `${baseDomain}?redirect=${encodeURIComponent(
+    storedRedirectUrl
+  )}`;
   console.log("!!!: RNG: Custom deep link URL: ", shareUrl);
 
   lucraClient?.sendMessage.deepLinkResponse({


### PR DESCRIPTION
## Summary
- build deep link share URLs from the current origin instead of localhost

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Invalid Options: Unknown options: useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)


------
https://chatgpt.com/codex/tasks/task_e_689fe0dee528832e9a40116bca728088