### PR TITLE
Handle Lucra matchup IDs in RNG flow

### DIFF
--- a/product-lucra-gyp/ios-app/RNGApp/Model/NumberRecord.swift
+++ b/product-lucra-gyp/ios-app/RNGApp/Model/NumberRecord.swift
@@ -10,5 +10,7 @@ import Foundation
 struct NumberRecord: Codable, Identifiable {
     var id: Int
     var value: Int
-    var created_at: String
+    var number: Int
+    var createdAt: String
+    var matchupId: String?
 }

--- a/product-lucra-gyp/ios-app/RNGApp/Service/API.swift
+++ b/product-lucra-gyp/ios-app/RNGApp/Service/API.swift
@@ -105,10 +105,8 @@ class APIService {
 
     // MARK: - Numbers
 
-    func generateNumber(userId: Int) async throws -> Int {
-        struct NumRes: Decodable { let number: Int }
-        let res: NumRes = try await request(path: "rng", userId: userId)
-        return res.number
+    func generateNumber(userId: Int) async throws -> NumberRecord {
+        try await request(path: "rng", userId: userId)
     }
 
     func getNumberHistory(page: Int, limit: Int, userId: Int) async throws -> NumbersResponse {

--- a/product-lucra-gyp/ios-app/RNGApp/Service/SessionManager.swift
+++ b/product-lucra-gyp/ios-app/RNGApp/Service/SessionManager.swift
@@ -9,6 +9,7 @@ import Combine
 import Foundation
 import LucraSDK
 import SwiftUI
+import UIKit
 
 class SessionManager: ObservableObject {
     
@@ -149,6 +150,10 @@ class SessionManager: ObservableObject {
             case .gamesMatchupStarted(let id):
                 self.notifyBackendOfMatchup(id: id)
                 self.flow = nil
+            case .gamesMatchupCreated(_):
+                self.presentMatchupAlert(created: true)
+            case .gamesMatchupAccepted(_):
+                self.presentMatchupAlert(created: false)
             default:
                 break
             }
@@ -158,6 +163,21 @@ class SessionManager: ObservableObject {
     private func notifyBackendOfMatchup(id: String) {
         Task {
             try await APIService.shared.matchupStarted(data: .init(matchupId: id), userId: user?.id ?? 0)
+        }
+    }
+
+    private func presentMatchupAlert(created: Bool) {
+        let verb = created ? "created" : "joined"
+        let message = "You've \(verb) a Lucra matchup, once the Creator starts the matchup, go back to RNG and generate a new number to complete your participation in this matchup! NOTE: If you have multiple matchups open, your scores will be applied to the oldest matchup open, one at a time"
+
+        DispatchQueue.main.async {
+            let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default))
+
+            if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+               let root = scene.windows.first?.rootViewController {
+                root.present(alert, animated: true)
+            }
         }
     }
 }

--- a/product-lucra-gyp/ios-app/RNGApp/Views/DashboardView.swift
+++ b/product-lucra-gyp/ios-app/RNGApp/Views/DashboardView.swift
@@ -6,6 +6,7 @@ struct DashboardView: View {
     @State private var targetNumber: Int?
     @State private var history: [Int] = []
     @State private var errorText: String?
+    @State private var currentMatchupId: String?
 
     var body: some View {
         ZStack {
@@ -63,10 +64,18 @@ struct DashboardView: View {
                 
                 HStack {
                     generateButton
-                    
+
                     if let _ = session.lucraUser {
                         createContestButton
                     }
+                }
+
+                if let matchupId = currentMatchupId {
+                    Button("This score applied to a Lucra Matchup!") {
+                        session.flow = .gamesMatchupDetails(matchupId: matchupId)
+                    }
+                    .foregroundColor(.white)
+                    .padding(.bottom, 20)
                 }
             }
         }
@@ -112,13 +121,15 @@ struct DashboardView: View {
             errorText = "Generating, please wait."
             return
         }
-        
+
         isGenerating = true
-        
+        currentMatchupId = nil
+
         Task {
             do {
-                let num = try await APIService.shared.generateNumber(userId: user.id)
-                targetNumber = num
+                let record = try await APIService.shared.generateNumber(userId: user.id)
+                targetNumber = record.number
+                currentMatchupId = record.matchupId
             } catch {
                 isGenerating = false
                 errorText = ""

--- a/product-lucra-gyp/ios-app/RNGApp/Views/HistoryView.swift
+++ b/product-lucra-gyp/ios-app/RNGApp/Views/HistoryView.swift
@@ -18,7 +18,7 @@ struct HistoryView: View {
                     HStack {
                         Text("\(item.value)")
                         Spacer()
-                        Text(item.created_at)
+                        Text(item.createdAt)
                             .font(.caption)
                     }
                     .foregroundColor(.white)


### PR DESCRIPTION
## Summary
- Parse new /rng response fields including optional matchupId
- Display link to Lucra matchup when RNG result applies to one
- Alert users after creating or joining a Lucra matchup via SDK events

## Testing
- `swift build` *(fails: cannot find type 'CFTypeRef' / module 'Security')*

------
https://chatgpt.com/codex/tasks/task_e_68a39cb4ccd4832eb6c94ce3dee10540